### PR TITLE
倒序排列食物制作清单

### DIFF
--- a/Script/UI/Panel/make_food_panel.py
+++ b/Script/UI/Panel/make_food_panel.py
@@ -132,7 +132,7 @@ class Make_food_Panel:
             now_draw.draw()
             food_name_list = list(
                 cooking.get_cook_from_makefood_data_by_food_type(self.now_panel).items()
-            )
+            )[::-1]
             # 将调味增加进去
             food_name_list = [(x[0], x[1], self.special_seasoning) for x in food_name_list]
             
@@ -161,7 +161,7 @@ class Make_food_Panel:
 
         food_name_list = list(
             cooking.get_cook_from_makefood_data_by_food_type(self.now_panel).items()
-        )
+        )[::-1]
         # 将调味增加进去
         food_name_list = [(x[0], x[1], self.special_seasoning) for x in food_name_list]
 


### PR DESCRIPTION
现状：做饭菜谱依据id排列，等级高的菜谱在最后方，在高等级情况下每次制作都需要先前往第二页再选择菜谱

代码修改后：倒序排列清单，使id最高的菜谱（如无意外是等级最高的菜谱）排在第一个
<img width="1909" height="376" alt="图片" src="https://github.com/user-attachments/assets/ef2f997e-7c93-48b7-b80a-6d262692a967" />



修改风险：已阅读食物系统文档，该系统与其他系统无联动，在博士房间与厨房进行测试时未出现报错、闪退等现象，不影响存档数据结构

AI声明：使用Copilot协助定位代码