### PR TITLE
修复外勤委托声望奖励的小数显示

### DIFF
--- a/Script/System/Field_Commission_System/field_commission_function.py
+++ b/Script/System/Field_Commission_System/field_commission_function.py
@@ -17,6 +17,22 @@ line_feed.width = 1
 window_width: int = normal_config.config_normal.text_width
 """ 窗体宽度 """
 
+
+def format_commission_reputation_for_display(value: float) -> str:
+    """
+    将声望数值格式化为最多两位小数的显示文本
+
+    Keyword arguments:
+    value -- 声望数值
+    Return arguments:
+    str -- 去除浮点尾数与无意义末尾零后的显示文本
+    """
+    display_text = f"{value:.2f}".rstrip("0").rstrip(".")
+    if display_text in ["", "-0"]:
+        return "0"
+    return display_text
+
+
 def update_field_commission():
     """
     刷新外勤委托的相关数据
@@ -337,10 +353,15 @@ def process_commission_text(now_text, demand_or_reward, deduction_or_increase, s
         type_text += f"{item_type}　"
 
     # 添加全文
+    display_now_have_item_num = now_have_item_num
+    display_item_num = item_num
+    if text_list[0] == "声望":
+        display_now_have_item_num = format_commission_reputation_for_display(now_have_item_num)
+        display_item_num = format_commission_reputation_for_display(item_num)
     if not demand_or_reward:
-        full_text += f"{item_name}:{now_have_item_num}/{item_num} "
+        full_text += f"{item_name}:{display_now_have_item_num}/{display_item_num} "
     else:
-        full_text += f"{item_name}:{item_num} "
+        full_text += f"{item_name}:{display_item_num} "
 
     return type_text, full_text, satify_flag
 


### PR DESCRIPTION
## 修复外勤委托声望奖励的小数显示

### 修改说明

仅在组装玩家可见的委托文本时格式化声望数值，避免委托完成后出现 `0.7000000000000001` 这类浮点尾数。声望的实际存储数值和奖励结算逻辑保持不变。

### 验证

- 在 Tk 模式中读取同一份准备好的存档，并通过游戏界面完成待结算的 `声望_0_70` 委托：修复前显示 `0.7000000000000001`，修复后显示 `0.7`。
- 在 Web 模式中重复相同操作：修复前显示 `0.7000000000000001`，修复后显示 `0.7`。
- 已运行 `python -m py_compile Script/System/Field_Commission_System/field_commission_function.py` 与 `git diff --check`。

### 截图

| 修复前 | 修复后 |
| --- | --- |
| ![修复前：声望显示为 0.7000000000000001](https://github.com/user-attachments/assets/6c515823-ad1a-4a19-b3bd-383fc6d02e22) | ![修复后：声望显示为 0.7](https://github.com/user-attachments/assets/58d656f1-d86b-4485-97dd-ecaa4ad7d582) |