### PR TITLE
修复场景全员前提的提前返回

### DIFF
--- a/Script/Design/handle_premise/handle_premise_place.py
+++ b/Script/Design/handle_premise/handle_premise_place.py
@@ -495,8 +495,7 @@ def handle_scene_all_unconscious(character_id: int) -> int:
             continue
         if handle_unconscious_flag_0(chara_id):
             return 0
-        return 1
-    return 0
+    return 1
 
 
 @add_premise(constant_promise.Premise.SCENE_ALL_UNCONSCIOUS_OR_SLEEP)
@@ -688,8 +687,7 @@ def handle_scene_all_fall_ge_2(character_id: int) -> int:
             continue
         if handle_self_not_fall(chara_id) or handle_self_fall_1(chara_id):
             return 0
-        return 1
-    return 0
+    return 1
 
 
 @add_premise(constant_promise.Premise.SCENE_ALL_NOT_TIRED)
@@ -715,8 +713,7 @@ def handle_scene_all_not_tired(character_id: int) -> int:
             continue
         if handle_self_tired(chara_id):
             return 0
-        return 1
-    return 0
+    return 1
 
 
 @add_premise(constant_promise.Premise.SCENE_ALL_NOT_H)
@@ -742,8 +739,7 @@ def handle_scene_all_not_h(character_id: int) -> int:
             continue
         if handle_self_is_h(chara_id):
             return 0
-        return 1
-    return 0
+    return 1
 
 
 @add_premise(constant_promise.Premise.SCENE_HAVE_MULTI_MASTUREBATE_TO_PL_CHARA)


### PR DESCRIPTION
## 修复场景全员前提的提前返回

### 修改说明

修复 `handle_premise_place.py` 中四个“场景内所有非玩家角色”前提的循环提前返回。

原实现会在第一个非玩家角色通过检查后立即返回成功，后续角色即使不满足条件也不会被检查。修复后会遍历完全部非玩家角色：遇到任一不满足的角色即返回失败；全部满足时才返回成功。

涉及的前提：

- `SCENE_ALL_UNCONSCIOUS`
- `SCENE_ALL_FALL_GE_2`
- `SCENE_ALL_NOT_TIRED`
- `SCENE_ALL_NOT_H`

### 验证

- Tk：使用三人场景存档复现 `SCENE_ALL_NOT_H`。第一个非玩家角色未处于 H，后一个处于 H；修复前“邀请群交”和“结束群交”同时出现，修复后只保留“结束群交”。
- Web：使用同一存档，修复前和修复后均可正常读取并进入主界面。当前 Web 新界面不直接列表显示这两个场景指令，因此未将它作为前后差异截图。
- 已运行：`python -m py_compile Script/Design/handle_premise/handle_premise_place.py`、`git diff --check`。

### 截图

| 修复前 | 修复后 |
| --- | --- |
| ![修复前](https://github.com/user-attachments/assets/e33e5819-24d7-4e6b-97cf-68537c0e81b5) | ![修复后](https://github.com/user-attachments/assets/87523e01-69f1-4006-aafe-2582237918af) |