### PR TITLE
修复玩家未移动时同一角色重复发现 H 行为

### DIFF
--- a/Script/System/Sex_System/hidden_sex_panel.py
+++ b/Script/System/Sex_System/hidden_sex_panel.py
@@ -241,6 +241,8 @@ def settle_discovered(character_id: int) -> None:
         return
     # 寻找是否有会发现的人
     interrupt_chara_list = get_nearby_conscious_unfallen_characters(character_id)
+    # 排除本次行动中已经处理过的发现者
+    interrupt_chara_list = [chara_id for chara_id in interrupt_chara_list if not cache.character_data[chara_id].sp_flag.see_pl_h]
     # 存在则进入被发现面板
     if len(interrupt_chara_list):
         from Script.System.Sex_System import sex_be_discovered_panel


### PR DESCRIPTION
## 问题

玩家进行隐奸时，附近角色可能发现玩家正在进行 H 行为，游戏随后会显示“H中被发现”选择界面。玩家可以在这个界面中处理发现者，例如用“花言巧语”暂时将对方支开。

此前，只要游戏再次检查附近是否有人发现 H 行为，同一角色就可能再次被选为发现者，即使该角色已经发现并被玩家处理过。这不仅会在发现者被支开、返回后发生，也可能在一次行动内连续触发多次发现检查时发生，例如一次行动同时引发多重高潮。

## 修改说明

游戏在角色发现 H 行为时，会用 `see_pl_h` 标记记录该角色已经发现过玩家。这个标记会一直保留，直到玩家移动到其他地点时统一重置。

现在，游戏选择下一名发现者时会排除仍带有 `see_pl_h` 标记的角色。因此，只要玩家没有移动，每名角色最多触发一次“H中被发现”界面；玩家移动后，所有角色可以按原有逻辑再次成为发现者。尚未发现过 H 的其他角色仍可正常被选中，原有候选顺序也保持不变。

这项修改只收窄最终发现者的选择范围，不改变通用的附近角色查询规则。该查询仍只负责判断角色是否在附近、是否清醒、是否未睡眠，以及是否符合隐奸发现条件。

## 验证

- Tk：使用同一份测试存档触发第一次发现后，选择“迅速地隐藏起来，转为隐奸”，并在玩家没有移动的情况下重新选择隐奸模式。修复前，惊蛰会立即再次显示“H中被发现”界面；修复后，惊蛰不会再次成为发现者。
- 聚焦测试：验证已经带有 `see_pl_h` 标记的角色会被排除；存在其他候选时，游戏会按原有顺序选择下一名角色；所有候选都已经发现过 H 时，不再显示发现界面。
- 已运行 `python -m py_compile Script/System/Sex_System/hidden_sex_panel.py` 与 `git diff --check`。

## 截图

| 修复前 | 修复后 |
| --- | --- |
| [![修复前：惊蛰重复触发两次发现界面](https://raw.githubusercontent.com/meower-z/erArk-fork/5ba724a6be4b4062e9516bcf90da815a29f7334f/pr-206/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/5ba724a6be4b4062e9516bcf90da815a29f7334f/pr-206/before.png) | [![修复后：惊蛰只触发一次发现界面](https://raw.githubusercontent.com/meower-z/erArk-fork/5ba724a6be4b4062e9516bcf90da815a29f7334f/pr-206/after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/5ba724a6be4b4062e9516bcf90da815a29f7334f/pr-206/after.png) |