### PR TITLE
修复跨系统读档后房间地址不匹配导致的场景角色丢失

### DIFF
--- a/Script/Core/save_handle.py
+++ b/Script/Core/save_handle.py
@@ -118,7 +118,83 @@ def write_save_data(save_id: str, data_id: str, write_data: dict):
         pickle.dump(write_data, f)
 
 
-def load_save(save_id: str) -> dict:
+def _normalize_save_path(path_text):
+    """
+    将存档中的路径文本转换为当前系统的路径格式
+    Keyword arguments:
+    path_text -- 可能包含其他系统路径分隔符的值
+    Return arguments:
+    str/object -- 字符串路径会被归一化，其他类型原样返回
+    """
+    foreign_sep = "\\" if os.sep == "/" else "/"
+    if isinstance(path_text, str) and foreign_sep in path_text:
+        return path_text.replace(foreign_sep, os.sep)
+    return path_text
+
+
+def _normalize_save_path_keys(path_dict):
+    """
+    归一化以场景或地图路径为键的存档字典
+    Keyword arguments:
+    path_dict -- 以路径文本为键的字典
+    Return arguments:
+    dict/object -- 有外来分隔符时返回归一化后的字典，否则原样返回
+    """
+    if not isinstance(path_dict, dict):
+        return path_dict
+    if not any(_normalize_save_path(key) != key for key in path_dict):
+        return path_dict
+    return {_normalize_save_path(key): value for key, value in path_dict.items()}
+
+
+def _normalize_loaded_save_paths(loaded_cache: game_type.Cache) -> None:
+    """
+    归一化反序列化存档中已知的结构性路径字段
+    Keyword arguments:
+    loaded_cache -- 从存档反序列化得到的游戏缓存
+    Return arguments:
+    None
+    """
+    scene_data = getattr(loaded_cache, "scene_data", None)
+    if isinstance(scene_data, dict):
+        loaded_cache.scene_data = _normalize_save_path_keys(scene_data)
+        for scene in loaded_cache.scene_data.values():
+            if hasattr(scene, "scene_path"):
+                scene.scene_path = _normalize_save_path(scene.scene_path)
+
+    map_data = getattr(loaded_cache, "map_data", None)
+    if isinstance(map_data, dict):
+        loaded_cache.map_data = _normalize_save_path_keys(map_data)
+        for map_data_value in loaded_cache.map_data.values():
+            if hasattr(map_data_value, "map_path"):
+                map_data_value.map_path = _normalize_save_path(map_data_value.map_path)
+
+    character_data = getattr(loaded_cache, "character_data", None)
+    if isinstance(character_data, dict):
+        for character in character_data.values():
+            if hasattr(character, "dormitory"):
+                character.dormitory = _normalize_save_path(character.dormitory)
+            if hasattr(character, "pre_dormitory"):
+                character.pre_dormitory = _normalize_save_path(character.pre_dormitory)
+            work_data = getattr(character, "work", None)
+            if work_data is not None and hasattr(work_data, "dormitory_admin_target_room"):
+                work_data.dormitory_admin_target_room = _normalize_save_path(work_data.dormitory_admin_target_room)
+            ability_data = getattr(character, "pl_ability", None)
+            if ability_data is not None and hasattr(ability_data, "air_hypnosis_position"):
+                ability_data.air_hypnosis_position = _normalize_save_path(ability_data.air_hypnosis_position)
+
+    rhodes_island = getattr(loaded_cache, "rhodes_island", None)
+    if rhodes_island is not None:
+        facility_damage_data = getattr(rhodes_island, "facility_damage_data", None)
+        if isinstance(facility_damage_data, dict):
+            rhodes_island.facility_damage_data = _normalize_save_path_keys(facility_damage_data)
+        maintenance_place = getattr(rhodes_island, "maintenance_place", None)
+        if isinstance(maintenance_place, dict):
+            for character_id, place in maintenance_place.items():
+                maintenance_place[character_id] = _normalize_save_path(place)
+
+
+def load_save(save_id: str) -> game_type.Cache:
     """
     按存档id读取存档数据
     Keyword arguments:
@@ -129,7 +205,9 @@ def load_save(save_id: str) -> dict:
     save_path = get_save_dir_path(save_id)
     file_path = os.path.join(save_path, "1")
     with open(file_path, "rb") as f:
-        return pickle.load(f)
+        loaded_cache = pickle.load(f)
+    _normalize_loaded_save_paths(loaded_cache)
+    return loaded_cache
 
 def input_load_save(save_id: str):
     """


### PR DESCRIPTION
## 问题

游戏把地图中的房间层级拼成字符串，并用这些“房间地址”作为场景和地图数据的索引。拼接时使用当前操作系统的路径分隔符，因此同一个房间在 Windows 存档中可能写成 `罗德岛\生活娱乐区\宿舍101`，在 Linux 中则写成 `罗德岛/生活娱乐区/宿舍101`。

存档会原样保存这些地址。玩家在另一种操作系统上读档时，存档中的旧地址无法与当前地图生成的地址对应。地图更新随后把旧地址下的场景当成已经删除的场景，连同其中保存的角色列表一起移除。

在本次复现中，一份保存了玩家和四名附近角色的 Windows 格式存档在 Linux 的 Tk 模式下读档后，场景界面找不到玩家角色并报出 `KeyError: 0`。

## 修改说明

现在，游戏在读取存档文件之后、执行跨版本数据更新之前，会把存档中已知的房间地址转换成当前操作系统使用的格式。处理范围包括：

- 场景数据的索引和场景自身记录的地址；
- 地图数据的索引和地图自身记录的地址；
- 角色的宿舍、原宿舍和宿舍管理员目标房间；
- 空气催眠记录的地点；
- 罗德岛设施损坏和维护记录中的地点。

转换只作用于这些明确属于地址的数据。当前系统已经使用正确格式的地址保持不变，台词、介绍等普通文本不会被扫描或改写。

这项修改不改变存档格式，也不重写地图、角色移动、Tk 或 Web 界面的逻辑。Windows 与 Linux 仍可按原有方式写出存档；兼容处理统一发生在读档入口。

## 验证

- Tk：使用同一份保存了玩家和四名附近角色的 Windows 格式存档在 Linux 中读档。修复前，场景界面报出 `KeyError: 0`；修复后，读档完成后直接显示正常场景界面，四名附近角色均保留并可见。
- 路径字段测试：验证外来分隔符会被转换、当前系统的地址保持不变，并且包含斜杠或反斜杠的普通文本不会被改写。
- 已运行 `python -m py_compile Script/Core/save_handle.py`、`git diff --check` 和证据目录中的聚焦测试脚本。

## 截图

| 修复前 | 修复后 |
| --- | --- |
| [![修复前：跨系统读档后场景界面报错](https://raw.githubusercontent.com/meower-z/erArk-fork/d038c4622c95ed4ae4a93b26e0176da61f7f8e82/pr-fix-cross-platform-save-paths/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/d038c4622c95ed4ae4a93b26e0176da61f7f8e82/pr-fix-cross-platform-save-paths/before.png) | [![修复后：跨系统读档后直接显示正常场景界面](https://raw.githubusercontent.com/meower-z/erArk-fork/d038c4622c95ed4ae4a93b26e0176da61f7f8e82/pr-fix-cross-platform-save-paths/after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/d038c4622c95ed4ae4a93b26e0176da61f7f8e82/pr-fix-cross-platform-save-paths/after.png) |
