### PR TITLE
修复群交 NPC 自动补位时意外切换玩家交互目标

### DIFF
--- a/Script/Design/handle_npc_ai_in_h.py
+++ b/Script/Design/handle_npc_ai_in_h.py
@@ -602,8 +602,12 @@ def npc_ai_in_group_sex(character_id: int):
             # print(f"debug {character_data.name}加入侍奉{game_config.config_status[ A_template_data[1][1]].name}")
         else:
             # 获取该部位的状态id列表
+            old_target_character_id = pl_character_data.target_character_id
             pl_character_data.target_character_id = character_id
-            new_status_id_list = group_sex_panel.get_status_id_list_from_group_sex_body_part(body_part)
+            try:
+                new_status_id_list = group_sex_panel.get_status_id_list_from_group_sex_body_part(body_part)
+            finally:
+                pl_character_data.target_character_id = old_target_character_id
             # 如果没有可用的状态，则返回
             if len(new_status_id_list) == 0:
                 return


### PR DESCRIPTION
## 问题

群交中的 NPC 自动补位时，会暂时把玩家的交互目标切换为当前候选 NPC，用于按该 NPC 的前提筛选可用姿势。该临时目标没有在筛选结束后恢复，因此 NPC 补位后，玩家当前选中的角色会被意外切换。

## 修复

在计算候选 NPC 的姿势列表前保存玩家原来的交互目标，并使用 `try/finally` 限定临时目标的生命周期。姿势列表计算结束后，无论是否找到可用姿势，都会恢复原来的目标。

群交模板的补位和姿势选择逻辑保持不变。

## 验证

在 Tk 模式触发一次群交 NPC 自动补位。

修复前，NPC 成功补位，但玩家原本选中的角色被切换为补位 NPC：

[![修复前：自动补位后意外切换玩家目标](https://raw.githubusercontent.com/meower-z/erArk-fork/2a13252b8cc637fef03688234019bc578c760341/pr-codex-preserve-group-ai-player-target/before.gif)](https://raw.githubusercontent.com/meower-z/erArk-fork/2a13252b8cc637fef03688234019bc578c760341/pr-codex-preserve-group-ai-player-target/before.gif)

修复后，NPC 仍然正常补位，玩家原本选中的角色保持不变：

[![修复后：自动补位后保持玩家原目标](https://raw.githubusercontent.com/meower-z/erArk-fork/2a13252b8cc637fef03688234019bc578c760341/pr-codex-preserve-group-ai-player-target/after.gif)](https://raw.githubusercontent.com/meower-z/erArk-fork/2a13252b8cc637fef03688234019bc578c760341/pr-codex-preserve-group-ai-player-target/after.gif)

另外运行了：

- `python -m py_compile Script/Design/handle_npc_ai_in_h.py`
- `git diff --check`
