### PR TITLE
修复：开启苦痛快感化后，减少苦痛的结算会错误扣减心理快感

### DIFF
--- a/Script/Settle/Second_effect.py
+++ b/Script/Settle/Second_effect.py
@@ -8,7 +8,7 @@ from Script.Design import (
 from Script.Core import cache_control, constant_effect, game_type, get_text
 from Script.Config import normal_config
 from Script.UI.Moudle import draw
-from Script.Settle.common_default import base_chara_experience_common_settle, base_chara_hp_mp_common_settle, base_chara_state_common_settle
+from Script.Settle.common_default import base_chara_experience_common_settle, base_chara_hp_mp_common_settle, base_chara_state_common_settle, route_pain_delta
 
 
 _: FunctionType = get_text._
@@ -1244,10 +1244,11 @@ def handle_add_small_pain(
     now_add_lust += now_lust / 20
     now_add_lust = int(now_add_lust)
 
-    character_data.status_data[17] += now_add_lust
-    character_data.status_data[17] = min(99999, character_data.status_data[17])
-    change_data.status_data.setdefault(17, 0)
-    change_data.status_data[17] += now_add_lust
+    pain_state_id, now_add_lust = route_pain_delta(character_id, now_add_lust)
+    character_data.status_data[pain_state_id] += now_add_lust
+    character_data.status_data[pain_state_id] = min(99999, character_data.status_data[pain_state_id])
+    change_data.status_data.setdefault(pain_state_id, 0)
+    change_data.status_data[pain_state_id] += now_add_lust
 
 
 @settle_behavior.add_settle_second_behavior_effect(constant_effect.SecondEffect.ADD_SMALL_TERROR)
@@ -1836,10 +1837,11 @@ def handle_add_middle_pain(
     now_add_lust += now_lust / 10
     now_add_lust = int(now_add_lust)
 
-    character_data.status_data[17] += now_add_lust
-    character_data.status_data[17] = min(99999, character_data.status_data[17])
-    change_data.status_data.setdefault(17, 0)
-    change_data.status_data[17] += now_add_lust
+    pain_state_id, now_add_lust = route_pain_delta(character_id, now_add_lust)
+    character_data.status_data[pain_state_id] += now_add_lust
+    character_data.status_data[pain_state_id] = min(99999, character_data.status_data[pain_state_id])
+    change_data.status_data.setdefault(pain_state_id, 0)
+    change_data.status_data[pain_state_id] += now_add_lust
 
 
 @settle_behavior.add_settle_second_behavior_effect(constant_effect.SecondEffect.ADD_MIDDLE_TERROR)
@@ -2621,10 +2623,11 @@ def handle_add_large_pain(
     adjust = attr_calculation.get_mark_debuff_adjust(character_data.ability[15])
     now_add_lust *= adjust
 
-    character_data.status_data[17] += now_add_lust
-    character_data.status_data[17] = min(99999, character_data.status_data[17])
-    change_data.status_data.setdefault(17, 0)
-    change_data.status_data[17] += now_add_lust
+    pain_state_id, now_add_lust = route_pain_delta(character_id, now_add_lust)
+    character_data.status_data[pain_state_id] += now_add_lust
+    character_data.status_data[pain_state_id] = min(99999, character_data.status_data[pain_state_id])
+    change_data.status_data.setdefault(pain_state_id, 0)
+    change_data.status_data[pain_state_id] += now_add_lust
 
 
 @settle_behavior.add_settle_second_behavior_effect(constant_effect.SecondEffect.ADD_LARGE_TERROR)
@@ -3195,17 +3198,21 @@ def handle_extra_orgasm(
         extra_terror *= adjust
         extra_terror = int(extra_terror)
         # 结算苦痛和恐怖
-        character_data.status_data[17] += extra_pain
-        character_data.status_data[17] = min(99999, character_data.status_data[17])
-        change_data.status_data.setdefault(17, 0)
-        change_data.status_data[17] += extra_pain
+        pain_state_id, extra_pain = route_pain_delta(character_id, extra_pain)
+        character_data.status_data[pain_state_id] += extra_pain
+        character_data.status_data[pain_state_id] = min(99999, character_data.status_data[pain_state_id])
+        change_data.status_data.setdefault(pain_state_id, 0)
+        change_data.status_data[pain_state_id] += extra_pain
         character_data.status_data[18] += extra_terror
         character_data.status_data[18] = min(99999, character_data.status_data[18])
         change_data.status_data.setdefault(18, 0)
         change_data.status_data[18] += extra_terror
         # 绘制信息
         now_draw = draw.NormalDraw()
-        now_text = _("\n{0}因为第{1}次的连续额外绝顶而被迫感受到了更多的苦痛和恐怖\n").format(character_data.name, all_extra_count)
+        if pain_state_id == 23:
+            now_text = _("\n{0}因为第{1}次的连续额外绝顶而被迫感受到了更多的心理快感和恐怖\n").format(character_data.name, all_extra_count)
+        else:
+            now_text = _("\n{0}因为第{1}次的连续额外绝顶而被迫感受到了更多的苦痛和恐怖\n").format(character_data.name, all_extra_count)
         now_draw.text = now_text
         now_draw.width = window_width
         now_draw.draw()

--- a/Script/Settle/common_default.py
+++ b/Script/Settle/common_default.py
@@ -1,5 +1,5 @@
 from types import FunctionType
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 from Script.Design import (
     character_handle,
     map_handle,
@@ -23,6 +23,30 @@ cache: game_type.Cache = cache_control.cache
 """ 游戏缓存数据 """
 width = normal_config.config_normal.text_width
 """ 屏幕宽度 """
+
+
+def route_pain_delta(
+        character_id: int,
+        pain_value: float,
+        continuous_adjust: float = 1,
+        ) -> Tuple[int, float]:
+    """
+    路由已计算完成的有符号苦痛增量
+    Keyword arguments:
+    character_id -- 角色id
+    pain_value -- 已计算完成的有符号苦痛增量
+    continuous_adjust -- 心理快感阶段的连续指令修正
+    Return arguments:
+    Tuple[int, float] -- 结算状态id与结算值
+    """
+    character_data: game_type.Character = cache.character_data[character_id]
+    if pain_value <= 0 or not character_data.hypnosis.pain_as_pleasure:
+        return 17, pain_value
+
+    final_adjust = chara_feel_state_adjust(character_id, 23, character_data.ability[36])
+    final_adjust *= continuous_adjust
+    final_value = int(pain_value * final_adjust)
+    return 23, final_value
 
 def base_chara_hp_mp_common_settle(
         character_id: int,
@@ -208,6 +232,7 @@ def base_chara_state_common_settle(
         final_adjust = chara_base_state_adjust(character_id, state_id, ability_level) + extra_adjust
 
     # 连续重复指令减值，非负面数值，仅玩家的交互对象
+    continuous_adjust = 1
     if state_id not in bad_state_set and character_id == pl_character_data.target_character_id:
         # 判断是否为连续指令
         if len(cache.pl_pre_behavior_instruce) >= 2 and cache.pl_pre_behavior_instruce[-1] == cache.pl_pre_behavior_instruce[-2]:
@@ -239,10 +264,13 @@ def base_chara_state_common_settle(
         final_value += tenths_value
     final_value = int(final_value)
 
-    # 心控-苦痛快感化，将苦痛状态转化为快感状态
-    if state_id == 17 and handle_premise.handle_hypnosis_pain_as_pleasure(character_id):
-        base_chara_state_common_settle(character_id, final_value, 23, 0, ability_level = character_data.ability[36], tenths_add = False, change_data = change_data, change_data_to_target_change = change_data_to_target_change)
-        return
+    # 心控-苦痛快感化，仅路由最终值为正的苦痛增量
+    if state_id == 17:
+        state_id, final_value = route_pain_delta(
+            character_id,
+            final_value,
+            continuous_adjust,
+        )
 
     # 结算最终值
     character_data.status_data[state_id] += final_value

--- a/Script/Settle/common_default.py
+++ b/Script/Settle/common_default.py
@@ -28,14 +28,12 @@ width = normal_config.config_normal.text_width
 def route_pain_delta(
         character_id: int,
         pain_value: float,
-        continuous_adjust: float = 1,
         ) -> Tuple[int, float]:
     """
     路由已计算完成的有符号苦痛增量
     Keyword arguments:
     character_id -- 角色id
     pain_value -- 已计算完成的有符号苦痛增量
-    continuous_adjust -- 心理快感阶段的连续指令修正
     Return arguments:
     Tuple[int, float] -- 结算状态id与结算值
     """
@@ -44,7 +42,6 @@ def route_pain_delta(
         return 17, pain_value
 
     final_adjust = chara_feel_state_adjust(character_id, 23, character_data.ability[36])
-    final_adjust *= continuous_adjust
     final_value = int(pain_value * final_adjust)
     return 23, final_value
 
@@ -269,7 +266,6 @@ def base_chara_state_common_settle(
         state_id, final_value = route_pain_delta(
             character_id,
             final_value,
-            continuous_adjust,
         )
 
     # 结算最终值


### PR DESCRIPTION
## 玩家可见问题

开启苦痛快感化后，本应减少苦痛的结算会错误地减少心理快感。例如对开启了该状态的角色使用 `[4103]体控-强制高潮`：该指令本应大幅减少苦痛，实际却把心理快感直接扣到清零（可低至 lv10→0），同时苦痛不降反升。

## 原因

苦痛快感化的转换逻辑没有区分苦痛变化的方向：只要开关开启，通用状态结算中任何针对苦痛的变化量——包括本应减少苦痛的负值——都被改道到心理快感结算。于是"减苦痛"变成了"减心理快感"，而苦痛本身反而漏过了这次减少。此外，绕过通用结算、直接增加苦痛的入口（小/中/大苦痛结算与连续额外绝顶的追加苦痛）完全不经过转换，开关开启时这些苦痛照常累加。

## 修复

把苦痛快感化的判定收拢为一条共用的路由规则：各结算入口先按原有方式算出本次的苦痛变化量，再由这条规则决定去向——只有正向的苦痛增量才在开关开启时转为心理快感，零和负向的变化仍按苦痛正常结算。路由只负责给出结算去向和数值，各入口原有的数值写入、上限和结算顺序保持不变。通用状态结算与直接增加苦痛的各个入口全部使用这同一条规则；连续额外绝顶实际发生转换时，提示文本也相应改为"心理快感和恐怖"，未转换时仍为"苦痛和恐怖"。

## 验证

Tk 界面下的真实主案例：相同初始状态，修复前后各执行一次 `[4103]体控-强制高潮`。

修复前，画面显示 `心理快感 -272586 (lv10->0)`——心理快感被清空，应有的苦痛减少没有发生；该次动作的整体结算最终显示 `苦痛 +3811`：

[![修复前：执行体控-强制高潮后，心理快感 -272586 (lv10->0)；应有的苦痛减少未发生，整体结算显示 苦痛 +3811](https://raw.githubusercontent.com/meower-z/erArk-fork/ec5f4e9d7458c56052a296e72af4bd3314d5934a/pr-codex-fix-signed-pain-routing/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ec5f4e9d7458c56052a296e72af4bd3314d5934a/pr-codex-fix-signed-pain-routing/before.png)

修复后，同一操作显示 `心理 +3656`、`苦痛 -31028 (lv7->4)`——苦痛正常减少，心理快感正常增加；过程中心理绝顶仍正常触发，最终结算含 `心理绝顶经验 +2`：

[![修复后：执行体控-强制高潮后，心理 +3656，苦痛 -31028 (lv7->4)](https://raw.githubusercontent.com/meower-z/erArk-fork/ec5f4e9d7458c56052a296e72af4bd3314d5934a/pr-codex-fix-signed-pain-routing/after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ec5f4e9d7458c56052a296e72af4bd3314d5934a/pr-codex-fix-signed-pain-routing/after.png)
