### PR TITLE
修复：解除催眠后"苦痛快感化"未被一并解除

### DIFF
--- a/Script/Design/hypnosis_state.py
+++ b/Script/Design/hypnosis_state.py
@@ -1,0 +1,22 @@
+from Script.Core import cache_control, game_type
+
+
+cache: game_type.Cache = cache_control.cache
+"""游戏缓存数据"""
+
+
+def clear_hypnosis_sub_states(target_character_id: int) -> None:
+    """
+    清理目标角色退出催眠时结束的心体催眠子状态。
+    Keyword arguments:
+    target_character_id -- 目标角色id
+    Return arguments:
+    None
+    """
+    target_character_data: game_type.Character = cache.character_data[target_character_id]
+
+    target_character_data.hypnosis.increase_body_sensitivity = False
+    target_character_data.hypnosis.blockhead = False
+    target_character_data.hypnosis.active_h = False
+    target_character_data.hypnosis.pain_as_pleasure = False
+    target_character_data.hypnosis.roleplay = []

--- a/Script/Settle/default.py
+++ b/Script/Settle/default.py
@@ -12,6 +12,7 @@ from Script.Design import (
     character_behavior,
     handle_npc_ai_in_h,
     handle_premise,
+    hypnosis_state,
     clothing,
     handle_ability,
     second_behavior,
@@ -1576,10 +1577,7 @@ def handle_hypnosis_cancel(
     if target_character_data.sp_flag.unconscious_h >= 4:
         target_character_data.sp_flag.unconscious_h = 0
     # 去掉大部分的心体催眠状态
-    target_character_data.hypnosis.increase_body_sensitivity = False
-    target_character_data.hypnosis.blockhead = False
-    target_character_data.hypnosis.active_h = False
-    target_character_data.hypnosis.roleplay = []
+    hypnosis_state.clear_hypnosis_sub_states(character_data.target_character_id)
     # 结算异常flag
     handle_premise.settle_chara_unnormal_flag(character_data.target_character_id, 5)
     handle_premise.settle_chara_unnormal_flag(character_data.target_character_id, 6)
@@ -5616,11 +5614,7 @@ def handle_hypnosis_flag_to_0(
         character_data.sp_flag.unconscious_h = 0
     handle_premise.settle_chara_unnormal_flag(character_id, 5)
     handle_premise.settle_chara_unnormal_flag(character_id, 6)
-    character_data.hypnosis.increase_body_sensitivity = False
-    character_data.hypnosis.blockhead = False
-    character_data.hypnosis.active_h = False
-    character_data.hypnosis.pain_as_pleasure = False
-    character_data.hypnosis.roleplay = []
+    hypnosis_state.clear_hypnosis_sub_states(character_id)
 
 
 @settle_behavior.add_settle_behavior_effect(constant_effect.BehaviorEffect.TARGET_ANGRY_WITH_PLAYER_FLAG_TO_0)


### PR DESCRIPTION

## 问题

对已被施加`苦痛快感化`的干员主动使用`[4004]解除催眠`后，`心控`等其他催眠子状态都已结束，但状态栏仍残留`(痛→快感)`，该效果实际继续生效。

作为对比，干员`熟睡`自然结束催眠时，`苦痛快感化`会随其他子状态一并解除。设计上两条退出路径应当一致：结束催眠时，同一组持续性心体催眠子状态应当全部结束。

## 原因

主动`解除催眠`的子状态清理代码写于 `pain_as_pleasure` 字段加入之前；该字段后来加入时没有补进这份旧的清理列表。而更晚建立的`熟睡`清理从一开始就包含它。于是两处各自维护了一份几乎相同的清理列表，其中主动`解除催眠`少了`苦痛快感化`这一项。

## 修复

新增一个共用函数，专门负责结束五项持续性心体催眠子状态：`敏感度提升`、`木头人`、体控`逆推`、`苦痛快感化`、`角色扮演`。主动`解除催眠`和`熟睡`都改为调用它，这份列表只表达一次，两条路径不会再各自漏项。

`熟睡`的行为不变；主动`解除催眠`补上了对`苦痛快感化`的清除，与`熟睡`对齐。

## 验证

用同一份存档，以凯尔希作为代表案例走同一操作流程：

- 操作前，凯尔希状态栏显示 `<催眠(200%):心控(敏感)(痛→快感)>`，同一画面可见`[4004]解除催眠`指令。

[![操作前：状态栏含 痛→快感，可见解除催眠指令](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-before.png)

- 上游当前版本：执行`[4004]解除催眠`后，状态栏仍显示 `<催眠(200%)(痛→快感)>`，效果残留。

[![上游当前版本：解除催眠后 痛→快感 残留](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-baseline-after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-baseline-after.png)

- 本 PR：同样操作后，状态栏显示 `<催眠(200%)>`，`痛→快感`已随其他子状态一并解除。

[![本 PR：解除催眠后 痛→快感 一并解除](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-candidate-after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/619d313c020af38c014e338a24b9bdbf59bb0efe/pr-213/direct-cancel-candidate-after.png)