### PR TITLE
修复 game_update_flow 嵌套调用返回后运行深度被误清零的问题

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -1786,7 +1786,7 @@ class Cache:
         self.over_behavior_character: Set = set()
         """ 本次update中已结束结算的npc """
         self.game_update_flow_running: int = 0
-        """ 游戏更新流程运行状态标志，用于防止递归调用导致的死循环 """
+        """ 游戏更新流程当前嵌套深度，用于限制递归调用层数 """
         self.pl_sleep_save_flag: bool = False
         """ 玩家睡觉，要进行存档 """
         self.recipe_data: Dict[int, Recipes] = {}

--- a/Script/Core/save_handle.py
+++ b/Script/Core/save_handle.py
@@ -285,7 +285,7 @@ def input_load_save(save_id: str):
 
     # 更新绘制模式
     loaded_dict["web_mode"] = cache.web_mode
-    # 重置防止递归调用的标志
+    # 重置游戏更新流程的嵌套深度
     loaded_dict["game_update_flow_running"] = 0
 
     # 遍历更新全角色属性

--- a/Script/Design/update.py
+++ b/Script/Design/update.py
@@ -9,7 +9,7 @@ def game_update_flow(add_time: int):
     Keyword arguments:
     add_time -- 游戏步进的时间
     """
-    # 检查是否已经在游戏更新流程中，防止递归调用导致死循环
+    # 深度达到上限时拒绝继续嵌套，防止递归调用导致死循环
     if cache_control.cache.game_update_flow_running >= 2:
         return
     

--- a/Script/Design/update.py
+++ b/Script/Design/update.py
@@ -13,8 +13,9 @@ def game_update_flow(add_time: int):
     if cache_control.cache.game_update_flow_running >= 2:
         return
     
-    # 设置游戏更新流程运行标志
-    cache_control.cache.game_update_flow_running += 1
+    # 保存调用者深度，并进入当前更新层级
+    caller_depth = cache_control.cache.game_update_flow_running
+    cache_control.cache.game_update_flow_running = caller_depth + 1
     
     try:
         # 去掉了第一次结算
@@ -23,5 +24,5 @@ def game_update_flow(add_time: int):
         character_behavior.init_character_behavior()
         py_cmd.focus_cmd()
     finally:
-        # 无论是否发生异常，都要清除运行标志
-        cache_control.cache.game_update_flow_running = 0
+        # 无论是否发生异常，都恢复调用者进入前的深度
+        cache_control.cache.game_update_flow_running = caller_depth


### PR DESCRIPTION
## 问题

`Script/Design/update.py` 的 `game_update_flow()` 用 `cache.game_update_flow_running` 记录更新流程的运行深度，并在深度达到 2 时拦截更深的嵌套调用。生产代码中存在嵌套路径：角色结算过程中，`recover_from_unconscious_h()` 会再次调用 `game_update_flow(5)`。旧实现在每一层的 `finally` 中都把标志固定清零，于是内层调用返回时，外层流程明明还在运行，深度却已被清成 0。此后该标志不再能正确反映外层仍在运行，后续的防重入判断失去了正确的深度依据。

## 修复

进入 `game_update_flow()` 时先保存调用者的深度 `caller_depth`，再将 `cache.game_update_flow_running` 置为 `caller_depth + 1`；`finally` 中不再固定清零，而是恢复为 `caller_depth`。这样每一层退出时只撤销自己增加的那一层深度，嵌套调用返回后外层深度保持正确。`>= 2` 的守卫阈值不变，时间推进、角色结算与聚焦的执行顺序也不变。