### PR TITLE
修复「H中被发现」面板中发现者反应漏结算与重复结算的问题

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -807,6 +807,8 @@ class SPECIAL_FLAG:
         """ 正在前往参与群交 """
         self.see_pl_h: bool = False
         """ 目击玩家H，在H被发现面板中使用，以免重复触发，玩家移动后重置 """
+        self.see_h_reaction_settled: bool = False
+        """ 目击H后的发现者反应已结算，NPC外层结算后重置 """
         self.sex_toy_level: int = 0
         """ 自己身上情趣玩具的档位，int，0关1弱2中3强 """
 

--- a/Script/Design/character_behavior.py
+++ b/Script/Design/character_behavior.py
@@ -170,7 +170,9 @@ def character_behavior(character_id: int, now_time: datetime.datetime, pl_start_
             # 寻找可用行动
             handle_npc_ai.find_character_target(character_id, now_time)
             # 结算状态与事件
-            judge_character_status(character_id)
+            if not character_data.sp_flag.see_h_reaction_settled or character_data.behavior.behavior_id == constant.Behavior.MOVE:
+                judge_character_status(character_id)
+            character_data.sp_flag.see_h_reaction_settled = False
         # 移动情况下也直接结算
         elif character_data.behavior.behavior_id == constant.Behavior.MOVE:
             # 结算状态与事件

--- a/Script/StateMachine/default.py
+++ b/Script/StateMachine/default.py
@@ -1321,6 +1321,7 @@ def character_see_h_and_move_to_dormitory(character_id: int):
     # 绘制被发现面板
     now_panel = sex_be_discovered_panel.Sex_Be_Discovered_Panel(normal_config.config_normal.text_width, character_id)
     now_panel.draw()
+    cache.character_data[character_id].sp_flag.see_h_reaction_settled = now_panel.discoverer_reaction_settled
 
 @handle_state_machine.add_state_machine(constant.StateMachine.SINGING)
 def character_singing(character_id: int):

--- a/Script/System/Sex_System/sex_be_discovered_panel.py
+++ b/Script/System/Sex_System/sex_be_discovered_panel.py
@@ -48,6 +48,8 @@ class Sex_Be_Discovered_Panel:
         """ 玩家角色数据 """
         self.target_chara_data = cache.character_data[self.pl_chara_data.target_character_id]
         """ 玩家交互对象数据 """
+        self.discoverer_reaction_settled = False
+        """ 发现者反应是否已结算 """
 
     def draw(self) -> None:
         """绘制面板"""
@@ -164,6 +166,7 @@ class Sex_Be_Discovered_Panel:
 
     def _let_find_chara_away(self) -> None:
         """选择用花言巧语支开对方"""
+        from Script.Design import character_behavior
         pass_flag = False
         now_draw_text = ""
         if self.find_chara_data.talent[222]:
@@ -179,6 +182,8 @@ class Sex_Be_Discovered_Panel:
             now_draw = draw.NormalDraw()
             now_draw.text = now_draw_text
             now_draw.draw()
+            character_behavior.judge_character_status(self.character_id)
+            self.discoverer_reaction_settled = True
         # 未通过
         else:
             self._end_current_h()
@@ -198,6 +203,7 @@ class Sex_Be_Discovered_Panel:
 
     def _continue_exhibitionism_sex(self) -> None:
         """选择转为露出"""
+        from Script.Design import character_behavior
         # 如果当前已经是露出模式
         if handle_premise.handle_exhibitionism_sex_mode_ge_1(0):
             # 判断对方的实行值
@@ -205,10 +211,14 @@ class Sex_Be_Discovered_Panel:
             if instuct_judege.calculation_instuct_judege(0, self.character_id, _("露出"))[0]:
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.SEE_H_BUT_IGNORE
                 self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
+                character_behavior.judge_character_status(self.character_id)
+                self.discoverer_reaction_settled = True
             # 如果是能接受H的等级，则自己离开
             elif instuct_judege.calculation_instuct_judege(0, self.character_id, _("H模式"))[0]:
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.SEE_H_AND_LEAVE
                 self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
+                character_behavior.judge_character_status(self.character_id)
+                self.discoverer_reaction_settled = True
             # 否则打断当前H
             else:
                 self._end_current_h()
@@ -233,10 +243,13 @@ class Sex_Be_Discovered_Panel:
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.JOIN_GROUP_SEX
                 self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
                 character_behavior.judge_character_status(self.character_id)
+                self.discoverer_reaction_settled = True
             # 不在群交中则转为群交
             else:
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.DISCOVER_OTHER_SEX_AND_JOIN
                 self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
+                character_behavior.judge_character_status(self.character_id)
+                self.discoverer_reaction_settled = True
                 handle_instruct.chara_handle_instruct_common_settle(constant.Behavior.OTHER_SEX_BE_FOUND_TO_GROUP_SEX)
                 # 结算成就
                 achievement_panel.get_achievement_judge_by_value(905, 1)
@@ -246,6 +259,7 @@ class Sex_Be_Discovered_Panel:
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.REFUSE_JOIN_GROUP_SEX
                 self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
                 character_behavior.judge_character_status(self.character_id)
+                self.discoverer_reaction_settled = True
             # 不在群交中则结束当前H
             else:
                 self._end_current_h()
@@ -260,6 +274,7 @@ class Sex_Be_Discovered_Panel:
         self.find_chara_data.behavior.duration = game_config.config_behavior[self.find_chara_data.behavior.behavior_id].duration
         # 手动结算该状态
         character_behavior.judge_character_status(self.character_id)
+        self.discoverer_reaction_settled = True
         # 如果是在群交中，则结束群交
         if handle_premise.handle_group_sex_mode_on(0):
             self.pl_chara_data.behavior.behavior_id = constant.Behavior.GROUP_SEX_END


### PR DESCRIPTION
## 问题

玩家 H 中被其他角色发现时会弹出「H中被发现」选择面板。面板有两个入口：NPC 在自己的回合目击玩家 H，以及隐奸流程的发现结算。玩家做出选择后，发现者本应恰好表现一次对应的反应（反应文本与数值效果），但两个入口下都不能保证：

- 部分选项分支只给发现者设置了反应行为，从未结算它。例如从隐奸入口进入面板，选择「用花言巧语支开对方」且判定通过后，发现者的被支开反应完全不出现，画面直接回到 H 文本。
- 另一部分分支在面板内已经结算过反应，但从 NPC 回合入口进入时，外层循环在面板关闭后还会无条件再结算一次，同一反应可能重复结算。

## 原因

面板各选项分支各自设置发现者的反应行为，但是否随即结算并不一致：「结束H」「加入群交」等分支会就地结算，「支开成功」「露出时对方接受并离开」等分支则不会。同时，NPC 外层循环在发现处理返回后总是再补一次结算，面板没有渠道告知外层「这次发现已经处理完」。两个入口各自叠加这两种不一致，就分别产生了漏结算和重复结算。

## 修复

1. 在缺少结算的四个分支就地补上发现者的反应结算：支开成功（`SEE_H_BUT_DECEIVED`）、露出时对方无视（`SEE_H_BUT_IGNORE`）、露出时对方接受后离开（`SEE_H_AND_LEAVE`）、初次发现转为群交（`DISCOVER_OTHER_SEX_AND_JOIN`）。反应结算一律先于结束 H 或转群交的后续处理执行，避免待结算的反应被后续流程覆盖。
2. 对「加入群交」「发现转群交」「无视」「打断」这类已在面板内完成全部反应处理的分支，面板做出完成标记，NPC 回合入口据此不再重放结算。
3. 「拒绝」「被支开」「接受后离开」这类分支按发现者反应后的实际状态收尾：反应使其真正进入移动（`MOVE`）时，外层本轮继续结算这次移动；寻路失败回退为原地等待（`WAIT`）时则跳过外层结算——反应本身已给出全部可见表现，不必再补一轮无事可做的等待。隐奸入口仍只结算发现反应本身。

本次修改不改变发现资格判断、话术/露出/H模式/群交的判定逻辑，也不改变同一发现者的再次发现规则和其他状态机分支的行为。

## 验证

与杜宾 H 中被可露希尔发现，选择「用花言巧语支开对方」且判定通过：

| 修复前 | 修复后 |
| --- | --- |
| [![修复前：判定通过后可露希尔没有任何反应文本，杜宾的H文本直接继续](https://raw.githubusercontent.com/meower-z/erArk-fork/e692de85089a29ec50e9015c8e2eba09e342cd1e/pr-codex-fix-discovery-settlement-ad-hoc/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/e692de85089a29ec50e9015c8e2eba09e342cd1e/pr-codex-fix-discovery-settlement-ad-hoc/before.png) | [![修复后：可露希尔的被支开反应恰好出现一次，随后杜宾的H文本正常继续](https://raw.githubusercontent.com/meower-z/erArk-fork/e692de85089a29ec50e9015c8e2eba09e342cd1e/pr-codex-fix-discovery-settlement-ad-hoc/after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/e692de85089a29ec50e9015c8e2eba09e342cd1e/pr-codex-fix-discovery-settlement-ad-hoc/after.png) |

两张截图对比的是这一条漏反应案例；其余分支的补结算与跳过重复结算属于同一返回路径上的对应处理。
