### PR TITLE
修复多角色结算时「X分钟过去了」被逐个面板重复输出的问题

### DIFF
--- a/Script/Design/settle_behavior.py
+++ b/Script/Design/settle_behavior.py
@@ -343,15 +343,6 @@ def handle_settle_behavior(character_id: int, now_time: datetime.datetime, event
                             judge = 1
                 if judge and (now_text != name) and cache.all_system_setting.draw_setting[7] == 1:
                     now_text_list.append(now_text)
-        if add_time > 0:
-            if not exchange_flag:
-                now_text_time = _("\n\n {0}分钟过去了\n").format(str(add_time))
-            else:
-                now_text_time = _("\n\n 该行动将持续{0}分钟\n").format(str(add_time))
-        else:
-            now_text_time = "\n"
-        if now_text_list:
-            now_text_list.append(now_text_time)
         # now_panel = panel.LeftDrawTextListPanel()
         now_text = "".join(now_text_list)
         now_panel = rich_text.get_rich_text_draw_panel(now_text)

--- a/Script/Design/update.py
+++ b/Script/Design/update.py
@@ -1,6 +1,6 @@
 import logging
 from Script.Design import character_behavior, game_time
-from Script.Core import py_cmd, cache_control
+from Script.Core import py_cmd, cache_control, get_text, io_init, web_server
 
 
 def game_update_flow(add_time: int):
@@ -16,6 +16,7 @@ def game_update_flow(add_time: int):
     # 保存调用者深度，并进入当前更新层级
     caller_depth = cache_control.cache.game_update_flow_running
     cache_control.cache.game_update_flow_running = caller_depth + 1
+    start_time = cache_control.cache.game_time
     
     try:
         # 去掉了第一次结算
@@ -23,6 +24,14 @@ def game_update_flow(add_time: int):
         game_time.sub_time_now(add_time)
         character_behavior.init_character_behavior()
         py_cmd.focus_cmd()
+        # 只有最外层更新在全部结算后按游戏时钟净差显示实际经过时间
+        if caller_depth == 0 and (elapsed_minutes := int((cache_control.cache.game_time - start_time).total_seconds() / 60)) > 0:
+            elapsed_text = get_text._("\n\n {0}分钟过去了\n").format(str(elapsed_minutes))
+            if cache_control.cache.web_mode:
+                cache_control.cache.web_instruct_texts.append(elapsed_text)
+                web_server.emit_realtime_text(elapsed_text, "instruct")
+            else:
+                io_init.era_print(elapsed_text)
     finally:
         # 无论是否发生异常，都恢复调用者进入前的深度
         cache_control.cache.game_update_flow_running = caller_depth


### PR DESCRIPTION
## 问题

一次行动结算涉及多名角色时，每个产生了结算内容的角色面板末尾都会各自输出一条「X分钟过去了」；NPC 对玩家行动的面板则输出「该行动将持续X分钟」。同一次游戏时间推进因此被多个面板分别宣告，群交时尤其明显；而且各条提示取的是该角色自己本次行为的时长，与本轮实际推进的游戏时间并不一致，容易误导玩家。

## 原因

经过时间的提示写在每个角色的结算面板里（`settle_behavior.handle_settle_behavior`），使用的是该角色本次行为的局部时长 `add_time`。有几个角色产生结算文本，就输出几条；这些局部时长相加也不等于本轮更新实际推进的游戏时钟。

## 修复

把经过时间的宣告从角色结算面板移到更新流程的最外层：

- 删除 `handle_settle_behavior` 中按角色追加「X分钟过去了」/「该行动将持续X分钟」的逻辑，角色结算面板不再输出任何时长提示。
- `game_update_flow` 在进入时记录游戏时钟，仅当自身处于最外层（依据现有的更新深度计数）时，在全部玩家与 NPC 结算完成后，按进入前后游戏时钟的净分钟差输出一条「X分钟过去了」；净差为零或负数则不输出，嵌套触发的更新也不单独输出。
- Tk 模式沿用原有文本输出方式；Web 模式仍写入 `web_instruct_texts` 并以 `instruct` 类型实时推送，只是从多条变为一条。

## 验证

- `python -m py_compile Script/Design/update.py Script/Design/settle_behavior.py` 通过。
- `git diff --check` 通过。

## 截图

修复前：群交中多名角色的结算块分别显示「5分钟过去了」。

[![修复前：群交中多名角色的结算块分别显示「5分钟过去了」](https://raw.githubusercontent.com/meower-z/erArk-fork/79f9e72a6ad350b48a8ee4d907a02ee52ee8d004/pr-220/before-multiple-five-minute-lines.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/79f9e72a6ad350b48a8ee4d907a02ee52ee8d004/pr-220/before-multiple-five-minute-lines.png)

修复后：群交中的多个角色结算块不再显示角色级时间提示。

[![修复后：群交中的多个角色结算块不再显示角色级时间提示](https://raw.githubusercontent.com/meower-z/erArk-fork/79f9e72a6ad350b48a8ee4d907a02ee52ee8d004/pr-220/after-no-character-time-lines.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/79f9e72a6ad350b48a8ee4d907a02ee52ee8d004/pr-220/after-no-character-time-lines.png)
