### PR TITLE
修复：异地干员的绝顶等H结算文本错误地显示给玩家

### DIFF
--- a/Script/Design/second_behavior.py
+++ b/Script/Design/second_behavior.py
@@ -143,8 +143,14 @@ def second_behavior_effect(
         if behavior_data != 0:
             if second_behavior_list and second_behavior_id not in second_behavior_list:
                 continue
-            # 触发二段行为的口上
-            talk.handle_second_talk(character_id, second_behavior_id)
+            # 触发二段行为的口上（异地NPC不显示结算口上，与上方必须结算门一致；
+            # 但必须显示(998)的行为——如经能力面板手动升级的刻印——不受在场限制）
+            if (
+                character_data.position == cache.character_data[0].position
+                or character_data.behavior.move_src == cache.character_data[0].position
+                or second_behavior_id in game_config.config_behavior_must_show_cid_list
+            ):
+                talk.handle_second_talk(character_id, second_behavior_id)
             # 如果没找到对应的结算效果，则直接跳过
             if second_behavior_id not in game_config.config_behavior_effect_data:
                 print(f"debug second_behavior_id = {second_behavior_id}没有找到对应的结算效果")

--- a/Script/Settle/Second_effect.py
+++ b/Script/Settle/Second_effect.py
@@ -2170,8 +2170,8 @@ def handle_milking_machine(
         character_data.pregnancy.milk -= now_milk
         character_data.behavior.milk_ml += now_milk
 
-        # 绘制信息
-        if now_milk:
+        # 绘制信息（异地NPC不向玩家绘制）
+        if now_milk and handle_premise.handle_in_player_scene(character_id):
             now_draw = draw.NormalDraw()
             now_text = _("\n{0}被搾乳机榨出了{1}ml的乳汁\n").format(character_data.name, now_milk)
             now_draw.text = now_text
@@ -2221,8 +2221,8 @@ def handle_urine_collector(
         character_data.urinate_point -= now_urine
         character_data.behavior.urine_ml += now_urine
 
-        # 绘制信息
-        if now_urine:
+        # 绘制信息（异地NPC不向玩家绘制）
+        if now_urine and handle_premise.handle_in_player_scene(character_id):
             now_draw = draw.NormalDraw()
             now_text = _("\n{0}被采尿器吸出了{1}ml的圣水\n").format(character_data.name, now_urine)
             now_draw.text = now_text
@@ -2266,11 +2266,12 @@ def handle_b_orgasm_to_milk(
         else:
             now_text = _("\n{0}在绝顶的同时喷出了{1}ml的乳汁，喷出的乳汁散落的到处都是\n").format(character_data.name, eject_milk)
 
-        # 绘制信息
+        # 绘制信息（异地NPC不向玩家绘制）
         now_draw = draw.NormalDraw()
         now_draw.text = now_text
         now_draw.width = window_width
-        now_draw.draw()
+        if handle_premise.handle_in_player_scene(character_id):
+            now_draw.draw()
 
 
 @settle_behavior.add_settle_second_behavior_effect(constant_effect.SecondEffect.U_ORGASM_TO_PEE)
@@ -2308,11 +2309,12 @@ def handle_u_orgasm_to_pee(
         else:
             now_text = _("\n{0}在绝顶的同时漏出了{1}ml的尿液，漏出的尿液在地上汇成一滩\n").format(character_data.name, eject_urine)
 
-        # 绘制信息
+        # 绘制信息（异地NPC不向玩家绘制）
         now_draw = draw.NormalDraw()
         now_draw.text = now_text
         now_draw.width = window_width
-        now_draw.draw()
+        if handle_premise.handle_in_player_scene(character_id):
+            now_draw.draw()
 
 
 @settle_behavior.add_settle_second_behavior_effect(constant_effect.SecondEffect.EXTRA_ORGASM)
@@ -2339,12 +2341,13 @@ def handle_extra_orgasm(
         extra_terror = int(100 * (1.2 ** all_extra_count))
         base_chara_state_common_settle(character_id, 0, 17, extra_pain, ability_level = character_data.ability[15], tenths_add = False, change_data = change_data)
         base_chara_state_common_settle(character_id, 0, 18, extra_terror, ability_level = character_data.ability[17], tenths_add = False, change_data = change_data)
-        # 绘制信息
+        # 绘制信息（异地NPC不向玩家绘制）
         now_draw = draw.NormalDraw()
         now_text = _("\n{0}因为第{1}次的连续额外绝顶而被迫感受到了更多的苦痛和恐怖\n").format(character_data.name, all_extra_count)
         now_draw.text = now_text
         now_draw.width = window_width
-        now_draw.draw()
+        if handle_premise.handle_in_player_scene(character_id):
+            now_draw.draw()
         # 额外高潮次数清零
         character_data.h_state.extra_orgasm_count = 0
 


### PR DESCRIPTION
## 问题

玩家不在场时，异地干员在H中的绝顶口上、连续额外绝顶、B绝顶喷乳、U绝顶漏尿，以及搾乳机/采尿器的每回合产出文本，仍会插进玩家的界面——玩家做完一次与之无关的操作后，会看到别处干员的这些结算文本。

实际路线：从训练场的健身区移动到走廊，移动结算里接连出现「琳琅诗怀雅双重绝顶」「琳琅诗怀雅触发了双重绝顶的地文」「陈双重绝顶」，而这几名干员都留在健身区、并不在玩家所在的走廊。

PR #215 已修复其中一类：多重绝顶的汇总口上（`plural_orgasm_2` 至 `plural_orgasm_11`）。但同一结算路径上的其余绝顶类显示点未被一并处理，异地泄漏仍然存在。

## 原因

`Script/Design/second_behavior.py` 的 `second_behavior_effect` 顶部已有一道门：当干员与玩家不同场景时，走静默分支并返回。但该门只在传入的二段行为列表为空时生效；高潮以非空列表单独调用它，绕过了这道门，于是绝顶类口上照常绘制。`handle_extra_orgasm`、`handle_b_orgasm_to_milk`、`handle_u_orgasm_to_pee`、搾乳机/采尿器等效果处理器各自直接绘制，同样没有"玩家是否在场"的判断。

游戏在其他同类结算处已用 `handle_premise.handle_in_player_scene(character_id)` 门控绘制（如人力发电、猥亵道具等）；上述泄漏点只是遗漏了这道既有的门。

## 修复

为遗漏的绝顶类显示点补上同一道"玩家在场"判断，只挡绘制、不影响数值与资源结算（乳汁/圣水入库、苦痛恐怖数值均照常）：

- 二段行为口上（`second_behavior_effect`）：异地时不绘制绝顶类口上；与顶部的门用同一"异地"判定，因此本回合刚从玩家处离开的干员仍会显示；标记为"必须显示"的行为（如刻印）不受在场限制。
- 连续额外绝顶、B绝顶喷乳、U绝顶漏尿、搾乳机、采尿器：异地时不绘制对应文本。

刻印升级与多重绝顶成就有持久影响（永久改变干员能力、解锁蚀刻章），仍在异地照常显示，不在本次范围内。

## 验证

同一存档、同一随机种子、同一玩家操作：读取存档后从训练场的健身区移动到走廊。

修复前：移动结算里接连出现「琳琅诗怀雅双重绝顶」「琳琅诗怀雅触发了双重绝顶的地文」「陈双重绝顶」，每条都需要点击才能翻过；而这几名干员都留在健身区，并不在玩家所在的走廊。

[![修复前：异地干员的多重绝顶提示逐条插入玩家界面](https://raw.githubusercontent.com/meower-z/erArk-fork/960ff330f0ef575f1c540a78d61471a52f9f8c48/pr-remote-orgasm-display-leak/before-remote-plural-orgasm-leaks.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/960ff330f0ef575f1c540a78d61471a52f9f8c48/pr-remote-orgasm-display-leak/before-remote-plural-orgasm-leaks.png)

修复后：同一移动直接完成并显示走廊场景，不再出现异地干员的绝顶提示。

[![修复后：同一移动直接完成并显示走廊场景](https://raw.githubusercontent.com/meower-z/erArk-fork/960ff330f0ef575f1c540a78d61471a52f9f8c48/pr-remote-orgasm-display-leak/after-move-completes-no-leak.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/960ff330f0ef575f1c540a78d61471a52f9f8c48/pr-remote-orgasm-display-leak/after-move-completes-no-leak.png)