### PR TITLE
修复：通用口上临时交互目标泄漏

### DIFF
--- a/Script/Design/talk.py
+++ b/Script/Design/talk.py
@@ -751,13 +751,18 @@ def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: 
     now_talk_text, special_code = special_code_judge(talk_text)
 
     # 替换通用文本
-    now_talk_text = talk_common_judge(now_talk_text, character_id)
+    original_target_character_id = player_data.target_character_id
+    try:
+        now_talk_text = talk_common_judge(now_talk_text, character_id)
+        common_target_character_id = player_data.target_character_id
+    finally:
+        player_data.target_character_id = original_target_character_id
 
     # 如果是纸娃娃地文文本，则将当前id改为玩家id
     if common_talk_flag:
         character_id = 0
         character_data = cache.character_data[character_id]
-        target_data = cache.character_data[character_data.target_character_id]
+        target_data = cache.character_data[common_target_character_id]
 
     # 专属称呼处理
     # 他人对自己的称呼
@@ -774,7 +779,7 @@ def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: 
     # 玩家的称呼
     if character_id != 0 and character_data.nick_name_to_pl != "":
         pl_nick_name = character_data.nick_name_to_pl
-    elif character_data.target_character_id != 0 and target_data.nick_name_to_pl != "":
+    elif (common_target_character_id if common_talk_flag else character_data.target_character_id) != 0 and target_data.nick_name_to_pl != "":
         pl_nick_name = target_data.nick_name_to_pl
     elif player_data.nick_name != "":
         pl_nick_name = player_data.nick_name
@@ -791,7 +796,7 @@ def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: 
         target_nick_name_to_pl = player_data.nick_name
 
     # 玩家的交互对象
-    pl_target_id = player_data.target_character_id
+    pl_target_id = common_target_character_id
     pl_target_name = ""
     if pl_target_id != 0:
         pl_target_data: game_type.Character = cache.character_data[pl_target_id]


### PR DESCRIPTION
## 问题

展开一句 NPC 的纸娃娃地文（含通用占位符）时，展开过程会把玩家的交互目标临时改成该 NPC 用于前提计算，但**返回后不恢复**。一次文本绘制因此永久改变玩家的交互对象，玩家的下一步动作会作用到这个被意外改写的目标上。

## 原因

`Script/Design/talk.py` 的 `talk_common_judge()` 在命中通用占位符、且该 NPC 与玩家同场景时改写玩家目标：

```python
if character_id != 0 and pl_character_data.target_character_id != character_id and handle_premise.handle_in_player_scene(character_id):
    pl_character_data.target_character_id = character_id
```

该改写只为展开期间的前提计算服务，但没有任何恢复逻辑。

## 修复

在 `code_text_to_draw_text()` 中给 `talk_common_judge()` 调用加上恢复边界：进入前保存原目标，`try` 中完成展开并把本次选中的 NPC 存入局部变量（供后续目标类占位符使用），`finally` 无条件恢复——正常返回和异常退出都恢复。后续格式化改读局部变量，不再依赖被改写的全局状态。

```python
original_target_character_id = player_data.target_character_id
try:
    now_talk_text = talk_common_judge(now_talk_text, character_id)
    common_target_character_id = player_data.target_character_id
finally:
    player_data.target_character_id = original_target_character_id
```

展开期间（前提计算、目标占位符）看到的状态与修复前逐位相同，单句展开结果不变；只是渲染结束后玩家目标回到原值。

## 验证

无头驱动真实生产函数 `code_text_to_draw_text(..., common_talk_flag=True)`，载入真实存档（玩家原交互目标为角色 367），对同场景的另一 NPC（角色 3）展开一句纸娃娃地文：

| | 展开前玩家目标 | 展开后玩家目标 |
|---|---|---|
| 修复前 | 367 | **3（泄漏为该 NPC）** |
| 修复后 | 367 | **367（已恢复）** |

## 影响范围

- 仅改动 `Script/Design/talk.py`（9 增 4 删）。
- 不改变 CSV/JSON 格式、存档格式或模组接口。
- 与“候选列表累积污染”修复相互独立，可单独审查与合并。
