### PR TITLE
修复力竭或疲劳的干员仍会被邀请加入群交的问题

### DIFF
--- a/Script/Core/constant_promise.py
+++ b/Script/Core/constant_promise.py
@@ -1341,6 +1341,8 @@
 
     SELF_TIRED = "self_tired"
     """ 特殊flag_生活 自身疲劳 """
+    SELF_EXHAUSTED = "self_exhausted"
+    """ 特殊flag_生活 自身力竭、疲劳或重度困倦（体力≤1、疲劳标记、或困倦等级≥2） """
     SELF_NOT_TIRED = "self_not_tired"
     """ 特殊flag_生活 自身未疲劳 """
     TARGET_HP_1 = "target_hp_1"

--- a/Script/Design/handle_premise/handle_premise_place.py
+++ b/Script/Design/handle_premise/handle_premise_place.py
@@ -371,14 +371,14 @@ def handle_scene_someone_no_fall(character_id: int) -> int:
 @add_premise(constant_promise.Premise.SCENE_SOMEONE_HP_1)
 def handle_scene_someone_hp_1(character_id: int) -> int:
     """
-    该地点有HP1或太疲劳的角色
+    该地点有力竭、疲劳或重度困倦的角色（体力≤1、疲劳标记、或困倦等级≥2）
     Keyword arguments:
     character_id -- 角色id
     Return arguments:
     int -- 权重
     """
     from Script.Design.handle_premise import (
-        handle_self_tired,
+        handle_self_exhausted,
     )
     character_list = map_handle.get_chara_now_scene_all_chara_id_list(character_id)
     # 场景角色数大于等于2时进行检测
@@ -389,7 +389,7 @@ def handle_scene_someone_hp_1(character_id: int) -> int:
         # 跳过玩家
         if chara_id == 0:
             continue
-        if handle_self_tired(chara_id):
+        if handle_self_exhausted(chara_id):
             return 1
     return 0
 
@@ -693,14 +693,14 @@ def handle_scene_all_fall_ge_2(character_id: int) -> int:
 @add_premise(constant_promise.Premise.SCENE_ALL_NOT_TIRED)
 def handle_scene_all_not_tired(character_id: int) -> int:
     """
-    该地点有玩家以外的角色，且所有角色都未疲劳
+    该地点有玩家以外的角色，且所有角色都可参加群交（未力竭、疲劳或重度困倦）
     Keyword arguments:
     character_id -- 角色id
     Return arguments:
     int -- 权重
     """
     from Script.Design.handle_premise import (
-        handle_self_tired,
+        handle_self_exhausted,
     )
     character_list = map_handle.get_chara_now_scene_all_chara_id_list(character_id)
     # 场景角色数大于等于2时进行检测
@@ -711,7 +711,7 @@ def handle_scene_all_not_tired(character_id: int) -> int:
         # 跳过玩家
         if chara_id == 0:
             continue
-        if handle_self_tired(chara_id):
+        if handle_self_exhausted(chara_id):
             return 0
     return 1
 

--- a/Script/Design/handle_premise/handle_premise_sp_flag.py
+++ b/Script/Design/handle_premise/handle_premise_sp_flag.py
@@ -43,6 +43,31 @@ def handle_self_tired(character_id: int) -> int:
         return 0
 
 
+@add_premise(constant_promise.Premise.SELF_EXHAUSTED)
+def handle_self_exhausted(character_id: int) -> int:
+    """
+    自身力竭、疲劳或重度困倦（体力≤1、带疲劳标记、或困倦等级≥2）
+    是 handle_self_tired（仅疲劳标记）的广义版本，供群交准入等需要"体力不支"判断处复用
+    Keyword arguments:
+    character_id -- 角色id
+    Return arguments:
+    int -- 权重，1为力竭/疲劳/重度困倦，0为正常
+    """
+    from Script.Design import attr_calculation
+
+    character_data: game_type.Character = cache.character_data[character_id]
+    # 体力耗尽（力竭）
+    if character_data.hit_point <= 1:
+        return 1
+    # 疲劳状态
+    if character_data.sp_flag.tired:
+        return 1
+    # 重度困倦（困倦等级≥2）
+    if attr_calculation.get_tired_level(character_data.tired_point) >= 2:
+        return 1
+    return 0
+
+
 @add_premise(constant_promise.Premise.SELF_NOT_TIRED)
 def handle_self_not_tired(character_id: int) -> int:
     """

--- a/Script/System/Sex_System/group_sex_panel.py
+++ b/Script/System/Sex_System/group_sex_panel.py
@@ -724,6 +724,9 @@ class Edit_Group_Sex_Temple_Panel:
                 # 判断实行值是否足够，不够的也跳过
                 if instuct_judege.calculation_instuct_judege(0, chara_id, _("群交"), not_draw_flag = True)[0] == False:
                     continue
+                # 力竭/疲劳/重度困倦者不再提供邀请
+                if handle_premise.handle_self_exhausted(chara_id):
+                    continue
                 # 判断是否被选择过
                 if handle_premise.handle_self_now_go_to_join_group_sex(chara_id):
                     selected_id_list.append(chara_id)
@@ -811,6 +814,9 @@ class Edit_Group_Sex_Temple_Panel:
             # 结算等待
             instuct_judege.init_character_behavior_start_time(character_id, cache.game_time)
             constant.handle_state_machine_data[0](character_id)
+        # 力竭/疲劳/重度困倦者无法被邀请加入群交
+        elif handle_premise.handle_self_exhausted(character_id):
+            info_draw_text = _("***{0}过于疲劳，无法参加群交***\n").format(character_data.name)
         # 否则邀请
         else:
             character_data.sp_flag.go_to_join_group_sex = True

--- a/Script/System/Sex_System/sex_be_discovered_panel.py
+++ b/Script/System/Sex_System/sex_be_discovered_panel.py
@@ -236,8 +236,8 @@ class Sex_Be_Discovered_Panel:
     def _invite_find_char_to_join(self) -> None:
         """选择邀请对方加入群交"""
         from Script.Design import character_behavior
-        # 判断是否满足加入群交条件
-        if handle_premise.handle_instruct_judge_group_sex(self.character_id):
+        # 判断是否满足加入群交条件（意愿达标且未力竭/疲劳/重度困倦）
+        if handle_premise.handle_instruct_judge_group_sex(self.character_id) and not handle_premise.handle_self_exhausted(self.character_id):
             # 如果当前在群交中，则直接加入
             if handle_premise.handle_group_sex_mode_on(0):
                 self.find_chara_data.behavior.behavior_id = constant.Behavior.JOIN_GROUP_SEX


### PR DESCRIPTION
## 问题

群交过程中打开「邀请其他干员 → 邀请干员参加群交」面板时，力竭、疲劳或重度困倦的干员仍会出现在可邀请列表中；选择邀请后，这些干员会先被标记为待加入并前往现场，随后又被群交逻辑剔除。「H中被发现」面板里对发现者选择「邀请对方加入群交」、以及直接邀请单个干员时，也存在同样的缺口。

原因是这些入口在决定「谁可以被邀请」时，只用了「群交」实行值判定（由好感、信赖等计算的意愿值），完全没有检查体力和疲劳状态。因此一个意愿达标但已经力竭的干员会正常通过判定。5055 号「邀请群交」指令的发起前提 `SCENE_ALL_NOT_TIRED` 虽然检查了疲劳，但只看疲劳标记，同样漏掉了力竭和重度困倦。

## 修复

新增一个共享前提 `handle_self_exhausted`——它是 `handle_self_tired`（只查疲劳标记）的广义版本，判定干员是否力竭（体力≤1）、带疲劳标记、或重度困倦（困倦等级≥2）。四个入口统一改用它排除这类干员：

- 「H中被发现」面板的「邀请对方加入群交」：发现者需同时通过实行值判定和体力疲劳判定。
- 群交模板面板的邀请干员列表：不合格的干员不再列出。
- 直接邀请单个干员：不合格时提示「过于疲劳，无法参加群交」，不再下发邀请。
- 5055 号「邀请群交」指令的前提 `SCENE_ALL_NOT_TIRED`：从只查疲劳标记改为使用同一共享判定。

顺带将前提 `SCENE_SOMEONE_HP_1`（注释为「该地点有HP1或太疲劳的角色」，但此前只检查疲劳标记）也改用同一判定，使其行为与注释一致。

已知限制：如果干员在被邀请之后才变得不合格，其待加入标记不会自动清除，该干员仍会前往现场并由后续群交逻辑剔除。现有成员与待加入成员的退出调度不在本次修改范围内。

## 效果对照

同一存档下「邀请干员参加群交」面板的前后对照——修复前被置为力竭/疲劳的阿米娅、陈、九、特蕾西娅仍出现在可邀请列表中，修复后这四人不再显示，其余合格干员照常列出。

**修复前（力竭/疲劳干员仍在列）：**

[![修复前 邀请面板](https://raw.githubusercontent.com/meower-z/erArk-fork/0603911855f2be0b157a8208044233b43fcb44e6/pr-fix-group-sex-admission-eligibility/baseline_invite_panel.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/0603911855f2be0b157a8208044233b43fcb44e6/pr-fix-group-sex-admission-eligibility/baseline_invite_panel.png)

**修复后（四人不再显示）：**

[![修复后 邀请面板](https://raw.githubusercontent.com/meower-z/erArk-fork/0603911855f2be0b157a8208044233b43fcb44e6/pr-fix-group-sex-admission-eligibility/candidate_invite_panel.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/0603911855f2be0b157a8208044233b43fcb44e6/pr-fix-group-sex-admission-eligibility/candidate_invite_panel.png)
