### PR TITLE
修复：NPC 多重绝顶后在同一次点击内被反复调度、堆叠大量口上

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -809,6 +809,8 @@ class SPECIAL_FLAG:
         """ 目击玩家H，在H被发现面板中使用，以免重复触发，玩家移动后重置 """
         self.see_h_reaction_settled: bool = False
         """ 目击H后的发现者反应已结算，NPC外层结算后重置 """
+        self.multi_orgasm_this_player_action: bool = False
+        """ 本次玩家行动（一次点击）内已发生多重绝顶；据此阻止其后续生成新的自主行为，最外层结算开始时重置 """
         self.sex_toy_level: int = 0
         """ 自己身上情趣玩具的档位，int，0关1弱2中3强 """
 

--- a/Script/Design/handle_npc_ai.py
+++ b/Script/Design/handle_npc_ai.py
@@ -236,6 +236,11 @@ def find_character_target(character_id: int, now_time: datetime.datetime):
     character_id -- 角色id
     """
     character_data: game_type.Character = cache.character_data[character_id]
+    # 本次行动内已多重绝顶的NPC，不再生成新的自主行为；直接加入结束列表，
+    # 由character_behavior()继续走judge_character_status()等被动结算尾部
+    if character_data.sp_flag.multi_orgasm_this_player_action:
+        cache.over_behavior_character.add(character_id)
+        return
     start_time = character_data.behavior.start_time
     all_target_list = list(game_config.config_target.keys())
     premise_data = {}

--- a/Script/Design/handle_npc_ai_in_h.py
+++ b/Script/Design/handle_npc_ai_in_h.py
@@ -581,6 +581,11 @@ def npc_ai_in_group_sex(character_id: int):
     if handle_premise.handle_self_now_bondage(character_id):
         return
 
+    # 本次行动内已多重绝顶的NPC，不再写入自慰意图或模板占位；
+    # 保留其现有群交参与关系，随后同一角色仍会到普通入口完成被动结算尾部
+    if character_data.sp_flag.multi_orgasm_this_player_action:
+        return
+
     # 如果设定NPC为仅自慰，则进入要自慰后返回
     if handle_premise.handle_npc_ai_type_1_in_group_sex(character_id):
         character_data.sp_flag.masturebate = 3

--- a/Script/Design/second_behavior.py
+++ b/Script/Design/second_behavior.py
@@ -541,6 +541,12 @@ def orgasm_settle(
                 draw_flag = True
             store_power_by_human_power(part_count + 3, character_id, draw_flag)
 
+    # 完整释放事务结束后，仅当本次为多重绝顶（>=2个部位同时高潮）才标记该NPC本次行动内已多重绝顶：
+    # 只有会展示大量口上的多重绝顶后的再调度才拦截，单部位高潮不受影响。
+    # 玩家（character_id为0）、成功寸止与时停蓄积（循环内continue使part_count保持0）也都不会走到这里。
+    if character_id and part_count >= 2:
+        character_data.sp_flag.multi_orgasm_this_player_action = True
+
 def judge_orgasm_degree(level_count: int) -> int:
     """
     判断高潮程度

--- a/Script/Design/update.py
+++ b/Script/Design/update.py
@@ -12,11 +12,16 @@ def game_update_flow(add_time: int):
     # 深度达到上限时拒绝继续嵌套，防止递归调用导致死循环
     if cache_control.cache.game_update_flow_running >= 2:
         return
-    
+
     # 保存调用者深度，并进入当前更新层级
     caller_depth = cache_control.cache.game_update_flow_running
     cache_control.cache.game_update_flow_running = caller_depth + 1
-    
+
+    # 最外层点击开始时重置全体NPC的“本次行动内多重绝顶”标记；嵌套更新复用同一标记，不重置
+    if caller_depth == 0:
+        for npc_id in cache_control.cache.npc_id_got:
+            cache_control.cache.character_data[npc_id].sp_flag.multi_orgasm_this_player_action = False
+
     try:
         # 去掉了第一次结算
         # character_behavior.init_character_behavior()


### PR DESCRIPTION
## 问题

在一次玩家行动的结算中，如果某个 NPC 发生了高潮释放——尤其是**多重绝顶**——在展示完大量绝顶口上之后，她仍可能在**同一次点击**内立即被重新调度、发起下一轮主动行为（例如再次自慰并再次绝顶）。于是同一次点击里反复主动、反复绝顶，堆叠出非常大量的口上，明显影响观感。

## 原因

NPC 的实际高潮释放统一在 `orgasm_settle()` 结算。此前没有"本次玩家行动内已释放"的记录，所以一次点击的结算中，NPC 完成一次（多重）绝顶后，其后续的自主行为生成入口——普通空闲 AI `find_character_target()` 与群交 `npc_ai_in_group_sex()`——仍会照常为她生成新的主动行为，形成同一点击内的绝顶连锁。

## 修复

新增一个与 `see_pl_h` 等同类的角色临时结算标记 `multi_orgasm_this_player_action`：

- `orgasm_settle()` 在完整释放事务结束后，**仅当本次为多重绝顶**（≥2 个部位在同一次结算中越过绝顶阈值，`part_count >= 2`）时为该 NPC 置位；单部位绝顶、玩家、成功寸止、时停蓄积都不置位。
- `game_update_flow()` 在每次**最外层**玩家行动开始时重置全体 NPC 的该标记；嵌套更新复用同一标记。
- `find_character_target()` 与 `npc_ai_in_group_sex()` 读取该标记：已多重绝顶的 NPC 在本次行动剩余结算中不再生成新的主动行为（不新建目标、自慰意图或群交模板占位），但**保留其群交参与关系并照常完成被动结算**（已发生的绝顶口上照常显示、照常加入结束列表）。下一次玩家行动开始时标记重置，NPC 可再次主动。

## 影响范围

只影响"刚发生过多重绝顶的 NPC 会不会在同一次玩家行动内又被安排一次主动行为"。单部位绝顶、玩家行动、寸止、时停、以及下一次玩家行动都不受影响；高潮数值公式、群交模板成员关系、通用 NPC 分钟调度均未改变。新增的 `sp_flag` 布尔字段会随角色存档，但每次最外层玩家行动开始必重置，不留跨行动/跨存档影响；旧存档经既有加载路径自动补默认值 `False`。

## 验证（真实 Tk 前后对比）

从**未改动**的 99 号存档的群交现场（贸易/山城茶馆，焦点为亚叶，其各部位快感为 0），固定随机种子，仅执行一个玩家指令：对亚叶**「舔阴」**。舔阴在同一次结算中同时增加亚叶的阴蒂快感与阴道快感，两者一并越过 lv1 阈值 → **亚叶双重绝顶**（`part_count == 2`）。修复前后直到该双重绝顶帧逐字节一致，唯一差异发生在其后。

[![触发帧（两侧一致）：亚叶双重绝顶](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/trigger_double_orgasm.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/trigger_double_orgasm.png)

**修复前**：同一次点击内，亚叶在双重绝顶后又**「开始自慰了」**并**「子宫小绝顶」**——被重新调度、发起了新的自主行为。

[![修复前：亚叶双重绝顶后同一点击内又开始自慰](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/baseline_rechain.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/baseline_rechain.png)

**修复后**：同一路线、同样推进，结算结束后回到指令菜单，**没有「亚叶开始自慰了」**——她被拦下；其欲情/快乐也低于修复前，说明少了那一轮自慰。（同场景的可露希尔只是单部位绝顶，两侧都不受拦截，说明只对多重绝顶生效。）

[![修复后：结算结束回到指令菜单，无新的自慰](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/candidate_gated.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/07c03f3a488d0860bcf9370d20263b9faa8740af/pr-add-per-click-orgasm-chain-gate/candidate_gated.png)

> 注：实际游玩的时候如果寸止失败产生非常多层绝顶，本身已经会展示大量口上，后面该干员继续执行动作来造成一次点击（e.g. 5分钟）内的多次绝顶信息，比较不符合游戏直觉。所以 propose 了这个修复。