### PR TITLE
修复移动途中进入H后角色仍会自行走完旧路线的BUG

### DIFF
--- a/Script/Design/character_move.py
+++ b/Script/Design/character_move.py
@@ -15,6 +15,18 @@ _: FunctionType = get_text._
 """ 翻译api """
 
 
+def cancel_movement_plan(character_id: int):
+    """
+    撤销角色尚未完成的移动计划，同时保留最后一次移动的起点和目标点
+    Keyword arguments:
+    character_id -- 角色id
+    Return arguments:
+    None -- 无返回值
+    """
+    character_data: game_type.Character = cache.character_data[character_id]
+    character_data.behavior.move_final_target = []
+
+
 def own_charcter_move(target_scene: list):
     """
     主角寻路至目标场景
@@ -49,6 +61,11 @@ def own_charcter_move(target_scene: list):
             character_data.action_info.ask_close_door_flag = False
             # print(f"debug pl start_time = {character_data.behavior.start_time}")
             update.game_update_flow(now_need_time)
+            # 若本段结算过程中移动计划被撤销（move_final_target 已不再指向 target_scene）
+            # 且尚未抵达目标，则停止寻路，不再走下一段
+            character_data = cache.character_data[0]
+            if character_data.position != target_scene and character_data.behavior.move_final_target != target_scene:
+                break
         else:
             break
     cache.character_data[0].target_character_id = 0

--- a/Script/Design/handle_npc_ai_in_h.py
+++ b/Script/Design/handle_npc_ai_in_h.py
@@ -230,7 +230,7 @@ def recover_from_unconscious_h(character_id: int, info_text: str = ""):
 
     # 如果继续H
     if continue_h:
-        target_data.sp_flag.is_h = True
+        default.handle_h_flag_to_1(target_data.cid, 1, game_type.CharacterStatusChange(), cache.game_time)
         character_data.behavior.behavior_id = constant.Behavior.WAIT
         character_data.state = constant.CharacterStatus.STATUS_WAIT
         # 对方的行为时间设为10分钟

--- a/Script/Settle/default.py
+++ b/Script/Settle/default.py
@@ -16,6 +16,7 @@ from Script.Design import (
     clothing,
     handle_ability,
     second_behavior,
+    character_move,
 )
 from Script.Core import cache_control, constant, constant_effect, game_type, get_text
 from Script.Config import game_config, normal_config
@@ -5111,6 +5112,10 @@ def handle_h_flag_to_1(
     if not add_time:
         return
     character_data: game_type.Character = cache.character_data[character_id]
+    # 只在从非H状态首次进入H时撤销旧移动计划；H状态中本effect仍会被反复结算，
+    # 此时is_h已为真而跳过，避免误删进入H后角色新下达的移动指令
+    if not character_data.sp_flag.is_h:
+        character_move.cancel_movement_plan(character_id)
     character_data.sp_flag.is_h = True
 
 


### PR DESCRIPTION
## 问题

当一名角色正在执行长途（多段寻路）移动、中途进入 H 时，其尚未走完的移动计划（`behavior.move_final_target`）不会被撤销。旧路线残留，导致该角色无视当前的 H 现场，继续走向最初的目的地。玩家和 NPC 各有一条正常游戏流程可达的触发路径：

**场景一：玩家被逆推（更严重，已实际观察到坏档）**。玩家正在执行一次多段移动，途中被欲望/攻略度足够高的干员逆推进入 H——同样经由 `handle_h_flag_to_1`——此刻 `move_final_target` 仍指向尚未抵达的终点。玩家的移动是 `own_charcter_move` 里的同步 `while` 循环，仅靠状态字段拦不住它：实际观察到玩家在进入 H 后仍被沿旧路线“带着走”，并曾因此导致存档损坏。

**场景二：NPC 目击并加入群交**。某干员正沿多段路线前往较远的目的地，走完一段后短暂空闲，`move_final_target` 仍指向终点（`character_behavior.py` 的空闲重置不清空该字段，`map_handle.py` 只在抵达最终终点时才清空）。这次空闲判定里，行动选择会在“继续赶路”与“目击玩家正在进行的 H”之间按权重竞争（`handle_npc_ai.find_character_target`）；若选中目击、玩家在被发现面板邀其加入群交，该干员执行 `discover_other_sex_and_join`（携带进入 H 的结算效果 462）进入 H，旧移动计划原样保留。H 结束后，下一次空闲判定因 `move_final_target` 非空重新选中“继续赶路”，干员径直离开 H 现场走向原目的地。

## 根因

进入 H 的状态切换统一由 `Script/Settle/default.py` 的 `handle_h_flag_to_1` 完成——全代码库中 `sp_flag.is_h = True` 只此一处赋值，任何角色（主角或交互对象）进入 H 都经过它。但该函数只置 `is_h` 标志，不清理已保存的移动计划 `behavior.move_final_target`，于是旧路线残留，H 期间及结束后被各处移动逻辑继续执行。

## 修复

共改动 3 个文件，+23/-1：

1. `character_move.py`：新增 `cancel_movement_plan(character_id)`，只清空该角色的 `move_final_target`（保留最后一段移动的起点/目标记录，仅撤销“待续走的最终目的地”这一计划）。
2. `default.py`：在 `handle_h_flag_to_1` 里以 `if not character_data.sp_flag.is_h` 为守卫调用 `cancel_movement_plan`——只在 `is_h` 由假变真的那一次进入切换上撤销，H 期间的重复结算不会误伤之后新建的移动计划。另加模块级 `import character_move`。
3. `handle_npc_ai_in_h.py`：把“无意识 H 恢复后继续 H”一处原先直接 `target_data.sp_flag.is_h = True` 的写法改为调用 `handle_h_flag_to_1(...)`，使该路径也走统一入口，不再有绕过共享入口的旁路赋值。

清空动作放在共享入口后，各条移动路径的覆盖方式：

- **NPC 续走**（`Script/StateMachine/default.py`）与**跟随移动**（`Script/Design/handle_npc_ai.py`）都以 `move_final_target != []` 为前置门槛，清空后自然不再续走，无需额外改动——场景二由此解决。
- **玩家自身移动**是 `own_charcter_move` 的同步 `while` 循环，按局部参数 `target_scene` 逐段推进，并不读取 `move_final_target`，仅清空拦不住它。为此在每段移动结算（`game_update_flow`）之后补一个中断判定：若本段结束后仍未抵达 `target_scene`、且 `move_final_target` 已不再等于 `target_scene`（即结算期间移动计划被撤销），则跳出循环，不再走下一段。共享入口负责清状态，这个中断负责停下同步循环——场景一由此解决。正常多段移动（计划未被撤销、`move_final_target` 仍等于目标）不受影响，抵达终点照常结束。

## 影响范围与验证

基于 `upstream/master`（`97c35826e`）做了代码级复核（未附运行时截图）：

- **循环导入**：`character_move` 是 `default.py` 导入元组的最后一项，其模块级依赖（`map_handle`/`update`/`draw`）此前均已加载完毕、且都不在模块级反向导入 `default`，不构成循环导入；三个文件 `py_compile` 通过。
- **入口唯一性**：修复后全库 `sp_flag.is_h = True` 仍仅 `handle_h_flag_to_1` 一处，进入 H 的路径全部收敛于此，路线撤销覆盖所有角色。
- **续走门槛**：核对 NPC 续走与跟随移动均以 `move_final_target != []` 为前置，清空即停。
- **玩家循环语义**：中断判定只在移动计划被撤销时触发，未进入 H 的正常多段移动与抵达终点两种情况均保持原行为。

### 复现步骤

场景一（玩家被逆推）：

1. 玩家发起一次需多段寻路的远距离移动。
2. 移动途中被欲望/攻略度足够高的干员逆推进入 H。
3. 修复前：玩家进入 H 后仍被沿旧路线带向原目的地（曾观察到由此产生存档损坏）；修复后：进入 H 的瞬间移动计划被撤销，当前段结算完成后循环中断，玩家停留在 H 现场。

场景二（NPC 目击加入）：

1. 让一名干员前往需多段寻路的远处目的地。
2. 玩家在其途经的某个中间场景与他人进行非隐藏 H。
3. 干员走到该场景后，在空闲判定中选中“目击玩家 H”，玩家在被发现面板上邀请其加入群交，干员进入 H；随后结束这场 H。
4. 修复前：干员继续沿原路线走向第 1 步的目的地、离开 H 现场；修复后：移动计划已在进入 H 时被撤销，干员停留原地。

> 说明：两个场景中“途经场景恰在路线上”“行动权重选中目击 / 干员发起逆推”属于概率性条件，但均为正常游戏流程可达的状态，非调试或人为构造。
