### PR TITLE
修正：修正了群交中体力耗尽的干员无法退出、且退出结算被重复触发的BUG

### DIFF
--- a/Script/Design/character_behavior.py
+++ b/Script/Design/character_behavior.py
@@ -111,11 +111,7 @@ def character_behavior(character_id: int, now_time: datetime.datetime, pl_start_
 
     # 处理特殊模式
     if character_id != 0:
-        handle_npc_ai.judge_character_tired_sleep(character_id) # 判断疲劳和睡眠
-        handle_npc_ai.judge_character_cant_move(character_id) # 无法自由移动的角色
-        handle_npc_ai.judge_assistant_character(character_id) # 助理
-        handle_npc_ai.judge_character_follow(character_id) # 跟随模式
-        handle_npc_ai_in_h.judge_character_h_obscenity_unconscious(character_id, pl_start_time) # H状态、猥亵与无意识
+        handle_npc_ai.run_npc_pre_behavior_checks(character_id, pl_start_time) # NPC行动前检查序列
 
     # 处理公共资源
     # update_cafeteria() # 刷新食堂的饭，不需要了，改为NPC在没有饭的时候自动刷新

--- a/Script/Design/handle_npc_ai.py
+++ b/Script/Design/handle_npc_ai.py
@@ -67,31 +67,9 @@ def judge_character_tired_sleep(character_id : int):
                     character_data.sp_flag.is_follow = 0
                 # 群交时
                 elif handle_premise.handle_group_sex_mode_on(character_id):
-                    # 自己退出
-                    character_data.target_character_id = character_id
-                    handle_instruct.chara_handle_instruct_common_settle(constant.Behavior.GROUP_SEX_NPC_HP_0_END, character_id)
-                    # 检测当前场景中的NPC角色数量
-                    scene_path_str = map_handle.get_map_system_path_str_for_list(character_data.position)
-                    scene_data: game_type.Scene = cache.scene_data[scene_path_str]
-                    # 去掉自己和玩家
-                    last_character_list = scene_data.character_list.copy()
-                    last_character_list.discard(0)
-                    last_character_list.discard(character_id)
-                    # 去掉HP为1和疲劳的角色
-                    for chara_id in last_character_list.copy():
-                        tem_character_data = cache.character_data[chara_id]
-                        if tem_character_data.hit_point <= 1 or tem_character_data.sp_flag.tired:
-                            last_character_list.discard(chara_id)
-                    # 如果自己退出后，剩余NPC角色数量小于等于1，则转为普通H
-                    if len(last_character_list) == 1:
-                        new_traget_id = last_character_list.pop()
-                        pl_character_data.target_character_id = new_traget_id
-                        pl_character_data.behavior.behavior_id = constant.Behavior.GROUP_SEX_TO_H
-                        pl_character_data.state = constant.CharacterStatus.STATUS_GROUP_SEX_TO_H
-                        character_behavior.judge_character_status(0)
-                    # 如果没有人了，则结束H
-                    elif len(last_character_list) == 0:
-                        handle_instruct.handle_group_sex_end()
+                    # 力竭退出只返回窄决定，交由调度器提交这一次转换；
+                    # 疲劳检查会被状态结算重入，若在此就地结算会造成嵌套周期与重复结算
+                    return constant.Behavior.GROUP_SEX_NPC_HP_0_END
 
                 # H时，有意识H则正常检测，无意识H则不检测疲劳，只检测HP
                 elif (
@@ -132,6 +110,64 @@ def judge_character_tired_sleep(character_id : int):
                 character_data.state = constant.CharacterStatus.STATUS_H_HP_0
                 # 调用结束H的指令
                 handle_instruct.handle_h_end()
+
+
+def run_npc_pre_behavior_checks(character_id: int, pl_start_time: datetime.datetime):
+    """
+    依次执行NPC的行动前检查序列\n
+    疲劳/睡眠检查判定为群交力竭退出时，由本序列提交这一次退出转换并跳过其余检查，\n
+    避免随后的H状态检查把退出行为覆盖为原地等待。\n
+    Keyword arguments:\n
+    character_id -- 角色id\n
+    pl_start_time -- 玩家行动开始时间\n
+    """
+    from Script.Design import handle_npc_ai_in_h
+
+    # 判断疲劳和睡眠；群交力竭退出时返回退出行为id，交由本序列提交转换
+    if judge_character_tired_sleep(character_id) == constant.Behavior.GROUP_SEX_NPC_HP_0_END:
+        commit_group_sex_tired_exit(character_id)
+        return
+    judge_character_cant_move(character_id) # 无法自由移动的角色
+    judge_assistant_character(character_id) # 助理
+    judge_character_follow(character_id) # 跟随模式
+    handle_npc_ai_in_h.judge_character_h_obscenity_unconscious(character_id, pl_start_time) # H状态、猥亵与无意识
+
+
+def commit_group_sex_tired_exit(character_id: int):
+    """
+    调度器提交群交力竭退出\n
+    配置退出行为并恰好结算一次退出效果链（清is_h、将角色移出群交模板等），\n
+    再按玩家所在场景仍在H的群交成员数沿用原有收尾：仅剩1人时转为普通H，\n
+    无人时由结束群交指令收尾，2人及以上则保持群交模式不变。\n
+    Keyword arguments:\n
+    character_id -- 力竭退出的NPC角色id\n
+    """
+    from Script.System.Instruct_System import handle_instruct
+
+    character_data: game_type.Character = cache.character_data[character_id]
+    # 目标指向自己并配置退出行为
+    character_data.target_character_id = character_id
+    handle_instruct.chara_handle_instruct_common_settle(constant.Behavior.GROUP_SEX_NPC_HP_0_END, character_id)
+    # 恰好结算一次，执行退出行为的清理效果链（1503欲望清零/528补HPMP上限/403重置H状态/635穿回衣服）
+    character_behavior.judge_character_status(character_id)
+    # 退出者is_h已被403清零；统计玩家所在场景仍在H的群交成员（不再误算非群交旁观者）
+    pl_character_data: game_type.Character = cache.character_data[0]
+    scene_path_str = map_handle.get_map_system_path_str_for_list(pl_character_data.position)
+    scene_data: game_type.Scene = cache.scene_data[scene_path_str]
+    remaining_ids = [
+        chara_id for chara_id in scene_data.character_list
+        if chara_id and cache.character_data[chara_id].sp_flag.is_h
+    ]
+    # 沿用原有收尾逻辑：仅剩1人转为普通H
+    if len(remaining_ids) == 1:
+        new_target_id = remaining_ids[0]
+        pl_character_data.target_character_id = new_target_id
+        pl_character_data.behavior.behavior_id = constant.Behavior.GROUP_SEX_TO_H
+        pl_character_data.state = constant.CharacterStatus.STATUS_GROUP_SEX_TO_H
+        character_behavior.judge_character_status(0)
+    # 已无仍在H的成员，由结束群交指令收尾
+    elif len(remaining_ids) == 0:
+        handle_instruct.handle_group_sex_end()
 
 
 def judge_assistant_character(character_id: int) -> int:


### PR DESCRIPTION
## 问题现象

群交进行中，若某位干员体力耗尽：

- 她的退出只是被“安排”却没有真正生效——系统仍把她当作群交的活跃参与者，她会继续做出H动作（例如“开始自慰”），而不是退场休息。
- 与此同时，退出的收尾流程会被反复触发，相关结算和提示文本重复出现多次。

## 原因

力竭退出的“判定”和“结算”原本写在同一处：疲劳检查一旦发现干员力竭，就当场执行整套退出收尾。但这段检查会在数值结算过程中被再次调用（重入），于是收尾流程被重复触发；而这次退出本身又会被随后的H状态检查覆盖，最终干员始终没有真正退出。

## 改动

把“判定”与“提交”分开：

- 疲劳检查遇到群交力竭时，只返回“该退出”的判定，不再就地结算。
- 由角色行为调度统一提交这一次退出——恰好结算一次退出流程（清除其H状态、移出群交），并跳过该角色其余的行动前检查，避免退出被覆盖。
- 退出完成后，按玩家所在场景仍在进行H的干员数量，沿用原有收尾规则：仅剩一人时转为普通H，无人时结束群交，两人及以上则群交照常继续。

## 效果

- 修复前：力竭干员退不出去，被当作活跃成员继续做H动作；且收尾被重复触发，结算与提示文本重复出现。
- 修复后：力竭干员打印“因为体力不足，(名字)只能提前离开了这次群交，自己先去休息”并干净退场，退出只结算一次；后续转为普通H或结束群交均沿用游戏原有规则，行为不变。


## 效果对照（真实 Tk 截图）

动作前（同一存档、同一按键，基线与候选起点像素完全一致）：

[![动作前：群交指令菜单](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/before.png)

动作后（力竭的亚叶应退出）：

| 修复前（基线） | 修复后（本 PR） |
| --- | --- |
| [![修复前：亚叶未退出、开始自慰，转普通H文本重复两次](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/baseline-after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/baseline-after.png) | [![修复后：亚叶打印退出口上并干净退场，转普通H只一次](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/candidate-after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/7b1b948d793ba124d0565983f13dc4d97b0cf957/pr-229/candidate-after.png) |

修复前：力竭的亚叶没有退出，被当作活跃成员`亚叶开始自慰了`，且“……只有博士和可露希尔还在……等待着下半场。”的转普通H文本重复出现两次。修复后：亚叶打印“因为体力不足，亚叶只能提前离开了这次群交，自己先去休息”并干净退场，转普通H叙述只出现一次。