### PR TITLE
feat: 快感栏部位名按绝顶寸止次数着色

### DIFF
--- a/Script/UI/Moudle/draw.py
+++ b/Script/UI/Moudle/draw.py
@@ -318,6 +318,8 @@ class InfoBarDraw:
         """ 是否为人物状态 """
         self.tooltip: str = ""
         """ 悬浮提示文本，供 Tk / Web 端展示额外说明 """
+        self.name_style: str = ""
+        """ 描述文本(标签)的字体样式，为空时用默认色 """
 
     def set(self, bar_id: str, max_value: int, value: int, text: str, tooltip: str = ""):
         """
@@ -343,6 +345,9 @@ class InfoBarDraw:
             info_draw.text = status_text
             lv_text = "lv" + text.split("lv")[1] + " "
             status_draw = StatusLevelDraw(value=value, text=lv_text)
+        # 按需给标签(描述文本)上色
+        if self.name_style:
+            info_draw.style = self.name_style
         value_draw = NormalDraw()
         value_draw.width = int(now_max_width / 3)
         value_draw.text = f"]({value}/{max_value})"

--- a/Script/UI/Panel/see_character_info_panel.py
+++ b/Script/UI/Panel/see_character_info_panel.py
@@ -379,17 +379,33 @@ class SeeCharacterStatusPanel:
         next_level_value = game_config.config_character_state_level[status_level].max_value
         now_text = f"{status_text}lv{status_level}"
         
+        # 寸止次数着色：该部位累积的绝顶寸止次数越多，部位名颜色越深(亮粉→深粉→红→紫 对应 1/2/3/4+次)
+        edge_count = character_data.h_state.orgasm_edge_count.get(status_id, 0)
+        edge_style = ""
+        part_tooltip = game_config.config_character_state[status_id].info
+        if edge_count >= 4:
+            edge_style = "levelex"  # 紫(#a020f0，复用EX评定色)，寸止最高档
+        elif edge_count == 3:
+            edge_style = "red"
+        elif edge_count == 2:
+            edge_style = "deep_pink"
+        elif edge_count == 1:
+            edge_style = "hot_pink"
+        if edge_count >= 1:
+            part_tooltip += _("绝顶寸止{0}次").format(edge_count)
+
         # 绘制状态条
         bar_draw = draw.InfoBarDraw()
         bar_draw.width = int(self.width / self.column)
         bar_draw.scale = 0.8
         bar_draw.chara_state = True
+        bar_draw.name_style = edge_style
         bar_draw.set(
             "StatusPointbar",
             next_level_value,
             status_value,
             now_text,
-            game_config.config_character_state[status_id].info,
+            part_tooltip,
         )
         self.draw_list.append(bar_draw)
         return True


### PR DESCRIPTION
## 动机

H 场景快感状态栏此前只在角色名旁显示一个 `<寸止>` 聚合标签，玩家无法一眼看出**哪些部位、被寸止到什么程度**。本 PR 把这一信息可视化到已有的逐部位快感条上。

## 改动

快感状态栏中，各部位名按该部位累积的绝顶寸止次数（`h_state.orgasm_edge_count`）着色，次数越多颜色越深；鼠标悬停显示"绝顶寸止X次"。

| 寸止次数 | 0 | 1 | 2 | 3 | 4+ |
|---|---|---|---|---|---|
| 颜色 | 默认灰 | 亮粉 `#ff69b4` | 深粉 `#ff1493` | 红 `#ff0000` | 紫 `#a020f0` |

紫色沿用等级评定 EX 的配色，作为"寸止封顶"档，与游戏既有 EX>S 的视觉认知一致。

## 实现

- `draw.InfoBarDraw` 新增实例属性 `name_style`（与已有的 `chara_state` 等配置属性一致），用于给标签（描述文本）指定字体样式；缺省为空、行为不变，不影响其它调用方，通用 `set()` 签名保持不动。
- `see_character_info_panel._draw_status_bar` 读取 `orgasm_edge_count` 映射到样式并赋给 `bar_draw.name_style`。

仅改 2 个文件，+22 −1 行，纯显示层，无逻辑/数值改动。

## 实机验证

真实游戏读档 → 邀请 H → 进入一对一 H 场景，快感栏五档配色如下（像素采样精确命中 `#c8c8c8 / #ff69b4 / #ff1493 / #ff0000 / #a020f0`）：

[![H场景快感栏按寸止次数染色](https://raw.githubusercontent.com/meower-z/erArk-fork/d0338b1a32095a8dd0044d52f9e90654d0a9b5f9/pr-edge-count-color/h-scene-status.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/d0338b1a32095a8dd0044d52f9e90654d0a9b5f9/pr-edge-count-color/h-scene-status.png)
