### PR TITLE
修正：修正了绝顶等二段结算的纸娃娃地文主语被错误替换为玩家的BUG

### DIFF
--- a/Script/Design/talk.py
+++ b/Script/Design/talk.py
@@ -303,7 +303,7 @@ def handle_talk_draw(character_id: int, talk_text: str, now_talk_id: str, second
         if special_code[0]:
             now_draw = draw.NormalDraw()
         # 获取最终输出文本
-        now_talk_text = code_text_to_draw_text(talk_text, character_id, common_behavior_id is not None)
+        now_talk_text = code_text_to_draw_text(talk_text, character_id, common_behavior_id is not None, second_behavior_id != "")
         now_draw.text = now_talk_text
         now_draw.width = normal_config.config_normal.text_width
         # 角色口上
@@ -733,13 +733,14 @@ def talk_common_judge(now_talk: str, character_id: int) -> str:
                     now_talk = pattern.sub(_replacer, now_talk)
     return now_talk
 
-def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: bool = False):
+def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: bool = False, second_behavior_flag: bool = False):
     """
     将文本中的代码转化为对应的文本 \n
     Keyword arguments: \n
     talk_text -- 输入的原文本 \n
     character_id -- 角色id \n
     common_talk_flag -- 是否为选择器生成的纸娃娃地文，默认为False \n
+    second_behavior_flag -- 是否为二段结算地文（如绝顶），默认为False \n
     Return arguments:
     now_talk_text -- 转化后的文本
     """
@@ -754,7 +755,9 @@ def code_text_to_draw_text(talk_text: str, character_id: int, common_talk_flag: 
     now_talk_text = talk_common_judge(now_talk_text, character_id)
 
     # 如果是纸娃娃地文文本，则将当前id改为玩家id
-    if common_talk_flag:
+    # 但二段结算地文（如绝顶）描写的是被结算角色本人，其{Name}应为该角色，不能强制改为玩家，
+    # 否则会出现“干员绝顶、结算文本却显示玩家名”的主谓错误
+    if common_talk_flag and not second_behavior_flag:
         character_id = 0
         character_data = cache.character_data[character_id]
         target_data = cache.character_data[character_data.target_character_id]


### PR DESCRIPTION
## 问题

H 中某位干员阴道绝顶时，屏幕先弹出橙色标题「（干员名）阴道小绝顶」，这一步是正确的；但紧接着的那段绝顶描写（纸娃娃地文）正文里，主语却变成了博士。这段描写本是按该干员的身体特征（如「少女」）选出的，套上博士的名字后就读成了"博士被当成少女在高潮"，主谓完全错乱。

## 原因

纸娃娃地文在渲染时会把当前角色统一改为玩家，以便通用文本以玩家为参照来描写。这对普通的动作类地文（如博士对干员做出动作的描写）是正确的；但绝顶这类二段结算的地文，描写对象本来就是被结算的那名干员本人，其 {Name} 应当是该干员，被统一改成玩家后就张冠李戴了。

## 修复

渲染纸娃娃地文时区分是否为二段结算：仅二段结算的地文不再把主语强制改为玩家，{Name} 保持为被结算的干员本人。其余纸娃娃地文的行为不变。

## 验证

Tk 模式，同一存档触发同一次阴道绝顶结算，两图的橙色标题与全部结算数值完全一致（均为干员「亚叶」获得阴道快感与阴道绝顶经验）。

修复前，绝顶正文主语通篇为「博士」，却套用了亚叶的少女身体描写，明显错乱：

[![修复前：绝顶正文主语为博士，套用的却是亚叶的身体描写](https://raw.githubusercontent.com/meower-z/erArk-fork/c06fab73f7a4243999c0eba74a73f9c11e5e346b/pr-fix-paperdoll-orgasm-subject/before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/c06fab73f7a4243999c0eba74a73f9c11e5e346b/pr-fix-paperdoll-orgasm-subject/before.png)

修复后，同一处绝顶结算的正文主语全部为「亚叶」，与其身体描写相符、文字通顺（两图正文为同批候选文本的不同变体，措辞不逐字相同）：

[![修复后：同处绝顶结算，主语纠正为该干员本人](https://raw.githubusercontent.com/meower-z/erArk-fork/c06fab73f7a4243999c0eba74a73f9c11e5e346b/pr-fix-paperdoll-orgasm-subject/after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/c06fab73f7a4243999c0eba74a73f9c11e5e346b/pr-fix-paperdoll-orgasm-subject/after.png)
