### PR TITLE
修复「切换催眠模式」后目标催眠状态未立即更新的问题

### DIFF
--- a/Script/UI/Panel/hypnosis_panel.py
+++ b/Script/UI/Panel/hypnosis_panel.py
@@ -294,6 +294,9 @@ class Chose_Hypnosis_Type_Panel:
             now_draw.draw()
             # 如果当前有交互对象
             if self.instruct_flag and pl_character_data.target_character_id:
+                # 依当前催眠类型对目标结算并套用催眠状态；未通过（催眠深度不足、或空气催眠地点不可锁门）则中止，不再向下宣告切换结果
+                if not evaluate_hypnosis_completion(pl_character_data.target_character_id):
+                    return
                 now_draw = draw.WaitDraw()
                 now_draw.style = "pink"
                 if hypnosis_type_cid == 1:


### PR DESCRIPTION
## 问题

对已被催眠的交互对象使用「切换催眠模式」指令选择新的催眠类型（平然/空气/体控/心控）后，目标的实际催眠状态并不会改变：状态栏里显示的仍是旧模式，要再执行一次催眠动作才会更新。切到体控/心控时，面板还会立刻弹出对应的控制子指令（如体控-木头人、心控-角色扮演），而这些子指令要求目标已处于该催眠状态，此时实际并不满足。

## 原因

面板的 `change_hypnosis_type` 只写入了博士当前选择的催眠类型；把催眠无意识状态套用到目标身上的是催眠结算函数 `evaluate_hypnosis_completion`，它只在单人/集体催眠动作结算时被调用。切换模式这一侧缺了“套用到目标”这一步。

## 修复

在指令模式下且有交互对象时，切换催眠类型后立即调用既有的 `evaluate_hypnosis_completion` 对目标结算并套用新的催眠状态。结算未通过时（催眠深度不足、或空气催眠所在地点无法锁门）则中止，不再作“切换成功”的宣告。

## 验证

Tk 模式下使用同一份存档，对已处于「心控」催眠的干员执行「切换催眠模式」选择「平然」。

修复前——切换后状态栏仍停留在 `<催眠(200%):心控>`：

[![修复前：切换后状态栏仍为心控](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-switch-apply/before_baseline_xinkong.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-switch-apply/before_baseline_xinkong.png)

修复后——切换后状态栏立即变为 `<催眠(200%):平然>`：

[![修复后：切换后状态栏变为平然](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-switch-apply/after_candidate_pingran.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-switch-apply/after_candidate_pingran.png)
