### PR TITLE
修复催眠状态下干员普通口上被无意识门禁吞掉的问题

### DIFF
--- a/Script/Design/handle_premise/__init__.py
+++ b/Script/Design/handle_premise/__init__.py
@@ -221,7 +221,8 @@ def get_weight_from_premise_dict(talk_premise_dict: set, character_id: int, calc
     premise_handlers = constant.handle_premise_data
 
     # 无意识模式判定
-    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id):
+    # 催眠类无意识（平然/空气/体控/心控，标记4~7）的目标仍在与博士互动，口上照常放行，不与睡眠/醉酒/时停一并门禁
+    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id) and not handle_unconscious_hypnosis_flag(target_character_id):
         # 有技艺tag的行为则直接通过
         behavior_data = game_config.config_behavior[behavior_id]
         if _("技艺") in behavior_data.tag:

--- a/Script/Design/handle_premise/__init__.py
+++ b/Script/Design/handle_premise/__init__.py
@@ -221,8 +221,8 @@ def get_weight_from_premise_dict(talk_premise_dict: set, character_id: int, calc
     premise_handlers = constant.handle_premise_data
 
     # 无意识模式判定
-    # 催眠类无意识（平然/空气/体控/心控，标记4~7）的目标仍在与博士互动，口上照常放行，不与睡眠/醉酒/时停一并门禁
-    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id) and not handle_unconscious_hypnosis_flag(target_character_id):
+    # 平然催眠下目标仍正常与博士互动，口上照常放行
+    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id) and not handle_unconscious_flag_4(target_character_id):
         # 有技艺tag的行为则直接通过
         behavior_data = game_config.config_behavior[behavior_id]
         if _("技艺") in behavior_data.tag:


### PR DESCRIPTION
## 问题

处于催眠状态（平然/空气/体控/心控）的干员，在被博士进行聊天等普通互动时几乎不会说任何普通口上，表现得像睡着或醉倒了一样。这与催眠的设定不符——尤其「平然」催眠的设定就是目标正常与博士交互，本该照常说话。

## 原因

口上权重计算 `get_weight_from_premise_dict` 中的无意识判定，把催眠类无意识（标记 4~7）与睡眠/醉酒/时停（标记 1~3）一视同仁：对非“技艺”类、且前提中不含 unconscious 的普通口上一律判权重 0，催眠状态干员的普通口上因此被全部过滤掉。

## 修复

在该判定条件中排除催眠类无意识（`handle_unconscious_hypnosis_flag`）：催眠状态的目标仍清醒并在与博士互动，其口上照常按各自前提正常结算。睡眠/醉酒/时停的门禁行为不变。

## 验证

Tk 模式下使用同一份存档，对已处于「心控」催眠的干员执行同一步「聊天」，两侧结算数值完全一致（好意+1066、快乐+481、气力−15、对话经验+1），仅口上有无不同。

修复前——没有口上，只有结算数值：

[![修复前：聊天无口上](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-talk-gate/before_baseline_no_line.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-talk-gate/before_baseline_no_line.png)

修复后——多出一行口上“杜宾谈起了自己的烹饪技巧，而博士则分享了自己最喜欢的食谱。”：

[![修复后：聊天出现口上](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-talk-gate/after_candidate_with_line.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/ce5b50870dcac31a2919a9c1f4bef3f341234d75/pr-fix-hypnosis-talk-gate/after_candidate_with_line.png)
