### PR TITLE
修复：单击指令按钮有时被误判为空白点击，导致下一个"按任意键继续"被跳过

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -22,8 +22,6 @@ class WFrameMouse:
     """ 鼠标右键按下 """
     w_frame_lines_up: int = 2
     """ 逐行输出状态 """
-    mouse_leave_cmd: int = 1
-    """ 鼠标左键事件 """
     w_frame_re_print: int = 0
     """ 再次载入游戏界面 """
     w_frame_lines_state: int = 2

--- a/Script/Core/key_listion_event.py
+++ b/Script/Core/key_listion_event.py
@@ -72,7 +72,7 @@ def mouse_left_check(event: Event):
     if not cache.wframe_mouse.w_frame_up:
         set_wframe_up()
     else:
-        mouse_check_push()
+        mouse_check_push(event)
 
 
 def mouse_right_check(event: Event):
@@ -87,7 +87,7 @@ def mouse_right_check(event: Event):
     if not cache.wframe_mouse.w_frame_up:
         set_wframe_up()
     else:
-        mouse_check_push()
+        mouse_check_push(event)
 
 
 def key_up(event: Event):
@@ -151,10 +151,29 @@ def set_wframe_up():
     cache.wframe_mouse.w_frame_lines_up = 1
 
 
-def mouse_check_push():
+def mouse_check_push(event: Event = None):
     """
-    更正鼠标点击状态数据映射
+    点击时现场判断落点是否命中指令按钮 tag，据此决定是否推进"按任意键继续"等待
+    Keyword arguments:
+    event -- 鼠标事件对象；用其屏幕坐标换算 textbox 内坐标做命中查询，None 时直接推进"按任意键继续"等待
     """
-    if not cache.wframe_mouse.mouse_leave_cmd == 0:
+    # 无事件对象时无法做命中查询，直接推进等待输入
+    if event is None:
         main_frame.send_input()
-        cache.wframe_mouse.mouse_leave_cmd = 1
+        return
+    textbox = main_frame.textbox
+    # 窗口级绑定的 event.x/y 相对 event.widget，不可直接用，故以屏幕坐标换算 textbox 内部坐标
+    tx = event.x_root - textbox.winfo_rootx()
+    ty = event.y_root - textbox.winfo_rooty()
+    # 落点若在 textbox 边界外，视作空白点击，推进等待输入
+    if tx < 0 or ty < 0 or tx >= textbox.winfo_width() or ty >= textbox.winfo_height():
+        main_frame.send_input()
+        return
+    # 取落点处的所有 tag，与已登记的指令按钮 tag（含文字与图片按钮，均登记在 cmd_tag_map）求交
+    point_tags = set(textbox.tag_names(f"@{tx},{ty}"))
+    cmd_tags = set(main_frame.cmd_tag_map.values())
+    # 命中任一指令按钮 tag → 本次为按钮点击，已由按钮回调处理，不再重复注入输入
+    if point_tags & cmd_tags:
+        return
+    # 未命中按钮 → 推进等待输入
+    main_frame.send_input()

--- a/Script/Core/main_frame.py
+++ b/Script/Core/main_frame.py
@@ -789,7 +789,6 @@ def io_print_cmd(
             textbox.tag_ranges(cmd_tag_name)[0],
             textbox.tag_ranges(cmd_tag_name)[1],
         )
-        cache.wframe_mouse.mouse_leave_cmd = 0
         if tooltip_text:
             coords = (event.x_root, event.y_root) if event is not None else None
             _schedule_tooltip(tooltip_text, coords)
@@ -808,7 +807,6 @@ def io_print_cmd(
             textbox.tag_ranges(cmd_tag_name)[1],
         )
         textbox.configure(cursor="")
-        cache.wframe_mouse.mouse_leave_cmd = 1
         _hide_tooltip()
 
     def motion_func(event=None):


### PR DESCRIPTION
## 问题（玩家现象）

单击一个指令按钮（尤其是图片按钮）后，紧随其后的"按任意键继续"等待偶尔会被自动跳过，一段文字没看到就翻过去了。触发没有规律，与鼠标是否移动过、界面是否滚动过有关。

## 原因

一次左键点击会同时触发两个处理：按钮文字自身的点击回调（发出按钮命令），和窗口级的全局点击回调。窗口级回调靠一个全局布尔 `mouse_leave_cmd`（"指针当前不在按钮上"）来判断这次点击是不是空白点击，是则向输入队列注入一次输入（通常是空串）用于推进等待。

这个布尔靠按钮文字的鼠标进入/离开（Enter/Leave）事件维护，有两个失效面：

1. **图片按钮从不更新它**（`io_print_image_cmd` 的 enter/leave 只管 tooltip）；
2. 文本滚动时指针不动、内容在动，Enter/Leave 事件会漏发。

布尔卡在错误值时，按钮点击被误判为空白点击，额外注入一条空串。空串滞留在输入队列里，被下一个"按任意键继续"当作玩家点击消费——于是那个等待被无输入跳过。

## 修改

不再信任累积维护的悬停布尔，改为**点击时现场判断落点**：

- `mouse_check_push` 接收事件对象，用屏幕坐标换算到 textbox 内坐标（窗口级绑定的 `event.x/y` 相对触发控件，不可直接用），越界视为空白；
- 用 `textbox.tag_names("@x,y")` 取落点处的 tag，与 `cmd_tag_map`（文字与图片按钮统一登记于此）求交：命中按钮 → 本次是按钮点击，已由按钮回调处理，不再注入；未命中 → 维持原行为；
- 右键路径经同一函数天然覆盖，跳过标志（`w_frame_skip_wait_mouse`）逻辑不变；
- `mouse_leave_cmd` 从此无人读取，一并删除（字段 + 两处写入）。存档兼容双向安全：旧档反序列化出的多余属性无人读取，新档在旧版本下回退到类级默认值。

## 验证

- 真实模块 A/B 对照（基线 = 未修改的 upstream/master）：基线复现全链条——点击图片按钮时输入队列收到 `[命令, 空串]`，残留空串使下一个等待无点击即结束；修复后只收到 `[命令]`，等待正确阻塞到真实点击。
- 等价性场景（空白点击推进、文字按钮点选、空输入框回车推进、右键推进+跳过、点击输入框）修复前后行为逐字节一致。
- 合成事件专项：图片按钮命中（含滚出视口再滚回）、最后一行下方空白点击的就近吸附（落到行末位置、无 tag，不会误判成按钮）。
- `python -m py_compile` 通过。

## 说明

曾考虑更简单的方案：在按钮点击回调末尾 `return "break"` 阻断窗口级回调。**实测证伪**——Tk 中 text tag 绑定的 break 只终止其余 tag 绑定，无法阻断窗口级 `<ButtonPress-1>`（对照实验：控件实例级绑定的 break 可以阻断，tag 级不行）。故本修复不含 break，全部有效性来自现场命中查询。

本修改仅涉及 Tk 桌面模式，Web 模式路径零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
