### PR TITLE
修正：H状态零时长行为完成时推进结算时钟，避免旧时间片被重复计入

### DIFF
--- a/Script/Design/character_behavior.py
+++ b/Script/Design/character_behavior.py
@@ -303,6 +303,7 @@ def judge_character_status_time_over(character_id: int, now_time: datetime.datet
     if not add_time:
         # 如果是H状态，则直接可以跳出
         if handle_premise.handle_self_is_h(character_id):
+            character_data.behavior.start_time = now_time
             return 1
         character_data.behavior = game_type.Behavior()
         character_data.behavior.start_time = now_time


### PR DESCRIPTION
## 问题描述

在群交状态下，群交模板模式是“优先填补空缺，否则自慰”的状态下，有时候单个 NPC 会在一次动作中自慰两次。这是上一个动作没有正确设置 NPC 的时钟导致的。

## 修改内容

- 在 `judge_character_status_time_over` 的 `add_time == 0`（本时间片零时长）分支内有三个出口：非H的两个出口都会先把 `behavior.start_time` 重置为 `now_time`，唯独角色仍处于H状态的出口原先直接 `return 1` 而保留旧的 `start_time`。当该角色随后切换到非零时长行为时，结算时钟会从这个未推进的旧时间继续，理论上可把已经消费过的时间片再次纳入逾期追赶结算。
- 修复为在该出口的 `return 1` 前新增一行 `character_data.behavior.start_time = now_time`，使这个完成出口与其他出口一致地消费当前时间片。