### PR TITLE
修正：恢复空气/体控/心控催眠状态下的口上与H地文显示

### DIFF
--- a/Script/Design/handle_premise/__init__.py
+++ b/Script/Design/handle_premise/__init__.py
@@ -221,8 +221,8 @@ def get_weight_from_premise_dict(talk_premise_dict: set, character_id: int, calc
     premise_handlers = constant.handle_premise_data
 
     # 无意识模式判定
-    # 平然催眠下目标仍正常与博士互动，口上照常放行
-    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id) and not handle_unconscious_flag_4(target_character_id):
+    # 催眠类无意识下目标仍在与博士互动，口上照常放行
+    if unconscious_pass_flag == False and handle_unconscious_flag_ge_1(target_character_id) and not handle_unconscious_hypnosis_flag(target_character_id):
         # 有技艺tag的行为则直接通过
         behavior_data = game_config.config_behavior[behavior_id]
         if _("技艺") in behavior_data.tag:


### PR DESCRIPTION
## 可见问题

PR #233 合并时按 maintainer 意见做了收窄，导致空气、体控、心控三种催眠状态下，目标的口上和 H 地文被通用无意识门禁拦截、不再显示。只有平然催眠仍能正常显示。但是游玩的时候发现这会导致 H 的所有文本都被拦下，没有任何文字可以读（只有黄色的高潮提示），这太影响游玩了。

建议在催眠相关功能进一步完善之前，暂时把四类催眠状态的口上和地文都恢复显示，保证这个功能暂时可以正常游玩。

## 修改

把例外判定从“仅平然”换成“任意催眠类无意识”。

`handle_unconscious_hypnosis_flag` 对 flag 4/5/6/7 均返回真，因此四类催眠状态全部绕过门禁、恢复显示；睡眠/醉酒/时停（flag 1/2/3）不在此集合，继续按原样被拦截。同时更新相邻注释。