### PR TITLE
fix: 检查衣柜时无精液不再显示“用衣服冲，射在上面”选项

### DIFF
--- a/Script/UI/Panel/check_locker_panel.py
+++ b/Script/UI/Panel/check_locker_panel.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Dict, List
 from types import FunctionType
 from Script.Core import cache_control, game_type, get_text, flow_handle, text_handle, constant, py_cmd
-from Script.Design import map_handle, attr_calculation, update, attr_text
+from Script.Design import map_handle, attr_calculation, update, attr_text, handle_premise
 from Script.UI.Moudle import draw, panel
 from Script.Config import game_config, normal_config
 from Script.UI.Panel import ejaculation_panel
@@ -165,6 +165,7 @@ class FindDraw:
         cloth_show_draw = draw.NormalDraw()
         self.pl_data.target_character_id = self.npc_id
         while 1:
+            return_list.clear()
             line = draw.LineDraw("-", window_width)
             line.draw()
             cloth_show_text = _("\n{0}的衣柜里放着刚脱下来的：\n").format(self.character_data.name)
@@ -234,17 +235,19 @@ class FindDraw:
                 button2_draw.draw()
                 return_list.append(button2_draw.return_text)
 
-            button3_text = _("[004]用衣服冲，射在上面")
-            button3_draw = draw.LeftButton(
-                _(button3_text),
-                _("4"),
-                window_width,
-                cmd_func=self.shoot_in_cloth,
-                args=(),
-                )
-            line_feed.draw()
-            button3_draw.draw()
-            return_list.append(button3_draw.return_text)
+            # 仅在玩家合计精液大于2ml时显示衣柜射精选项
+            if handle_premise.handle_pl_semen_g_2(0):
+                button3_text = _("[004]用衣服冲，射在上面")
+                button3_draw = draw.LeftButton(
+                    _(button3_text),
+                    _("4"),
+                    window_width,
+                    cmd_func=self.shoot_in_cloth,
+                    args=(),
+                    )
+                line_feed.draw()
+                button3_draw.draw()
+                return_list.append(button3_draw.return_text)
 
             # return_list.append(button0_draw.return_text)
             # button_all_draw.draw_list.append(button0_draw)


### PR DESCRIPTION
**问题**：检查干员衣柜时，“[004]用衣服冲，射在上面”这个射精选项始终显示。即使玩家精液已经耗尽，仍然可以继续选择该选项向衣物射精，与射精类行为需要玩家还有精液的规则不符。

**原因**：check_cloth() 在绘制衣柜界面时无条件绘制该按钮，没有检查玩家当前的精液量。此外，界面用 while 循环反复重绘，而 return_list 只在循环外初始化一次、循环内从不清空，导致可接受的输入跨轮次累积——即便某个按钮本轮没有画出，它残留的输入仍会被 askfor_all 接受。

**修复**：绘制该按钮前用前提 handle_pl_semen_g_2（玩家合计精液大于 2ml）判断，精液耗尽时不再显示该选项；同时在每轮循环开头清空 return_list，使可接受的输入始终与本轮实际画出的按钮一致——否则选项虽被隐藏，残留的输入“4”仍能触发射精动作。
