### PR TITLE
fix(tk): 修复 Tk 模式输出区可拖选并回车删除文本导致卡死 (#247)

### DIFF
--- a/Script/Core/main_frame.py
+++ b/Script/Core/main_frame.py
@@ -364,6 +364,25 @@ inputbox = Entry(
     width=normal_config.config_normal.inputbox_width,
 )
 inputbox.grid(column=1, row=0, sticky=(N, E, S))
+
+
+def _return_focus_to_inputbox(event=None):
+    """
+    将键盘焦点交还给底部输入框。
+    输入：event —— Tk 事件对象，可为 None；返回值：None。
+    """
+    inputbox.focus_set()
+
+
+# 输出显示区（textbox）是纯展示控件，绝不应持有键盘焦点。
+# 一旦它拿到焦点，Tk Text 的类绑定会让“拖选文本后按回车/任意键”把选区内容当作输入
+# 直接删除，破坏界面布局，甚至在需要文本输入的场景（如输入购买数量再回车）删掉提示后
+# 卡住无法推进（issue #247）。此处令 textbox 永不持有键盘焦点：任何使其获得焦点的操作
+# （点击、Tab）都立即把焦点交还输入框，从根源杜绝在显示区用键盘编辑/删除文本。
+# 鼠标滚轮滚动、拖选、复制均不依赖键盘焦点，故都不受影响；真正的文本输入走独立的 inputbox。
+textbox.configure(takefocus=0)
+textbox.bind("<FocusIn>", _return_focus_to_inputbox)
+
 normal_font = font.Font(family=order_font_data.font, size=normal_config.config_normal.font_size)
 
 


### PR DESCRIPTION
Fixes #247

## 现象

Tk 模式下，在输出区按住鼠标左键拖动会选中屏幕文字（选区通常不可见）；此时按回车会把选中的文字当作输入删除，界面布局错乱。若发生在需要文本输入的场景（如输入购买数量后回车），删掉提示后游戏无法继续、卡死。

## 根因

输出显示区 `textbox` 是纯展示控件，但默认会接受键盘焦点。一旦它持有焦点，Tk `Text` 的类绑定就把「拖选 + 回车」当作编辑操作删除选区。真正的文本输入走的是另一个独立的 `inputbox`（`Entry`），`textbox` 本不该持有键盘焦点。

## 修复

只改 `Script/Core/main_frame.py`（+19 行）：给 `textbox` 设 `takefocus=0`，并绑定 `<FocusIn>` 在其获得焦点时立即把焦点交还 `inputbox`，使输出区永不持有键盘焦点。改在控件创建处，覆盖所有输出路径，不触碰独立的输入框。（未采用移除 `Text` bindtag 的做法：那会误伤鼠标滚轮滚动。）

## 截图

同一拖选手势后按回车的前后对照：

**手势前**（基线与修复后完全一致）

[![真实游戏-手势前](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_before.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_before.png)

| 基线（无修复）：回车后场景块被删、界面损坏 | 修复后：回车后界面完好无损 |
| --- | --- |
| [![真实基线-回车后](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_baseline_after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_baseline_after.png) | [![真实修复后-回车后](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_candidate_after.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/bbbf0fead2fc117a81eb7f504dc64a683b8ea46c/pr-255/real_candidate_after.png) |

## 验证

同一手势下，基线删除文本、修复后不再删除；窗口级 `send_input` 仍正常触发，游戏正常推进。输入框打字、鼠标滚轮滚动、拖选复制均不受影响。