### PR TITLE
修正：时停积累的高潮未计入状态栏部位名着色（#249）

### DIFF
--- a/Script/UI/Panel/see_character_info_panel.py
+++ b/Script/UI/Panel/see_character_info_panel.py
@@ -379,8 +379,9 @@ class SeeCharacterStatusPanel:
         next_level_value = game_config.config_character_state_level[status_level].max_value
         now_text = f"{status_text}lv{status_level}"
         
-        # 寸止次数着色：该部位累积的绝顶寸止次数越多，部位名颜色越深(亮粉→深粉→红→紫 对应 1/2/3/4+次)
-        edge_count = character_data.h_state.orgasm_edge_count.get(status_id, 0)
+        # 高潮积累着色：该部位待结算的绝顶次数越多，部位名颜色越深(亮粉→深粉→红→紫 对应 1/2/3/4+次)
+        # 寸止(orgasm_edge_count)与时停(time_stop_orgasm_count)本质是同一种"快感越过阈值但未结算"的积累，一并计入
+        edge_count = character_data.h_state.orgasm_edge_count.get(status_id, 0) + character_data.h_state.time_stop_orgasm_count.get(status_id, 0)
         edge_style = ""
         part_tooltip = game_config.config_character_state[status_id].info
         if edge_count >= 4:
@@ -392,7 +393,7 @@ class SeeCharacterStatusPanel:
         elif edge_count == 1:
             edge_style = "hot_pink"
         if edge_count >= 1:
-            part_tooltip += _("绝顶寸止{0}次").format(edge_count)
+            part_tooltip += _("(绝顶寸止{0}次)").format(edge_count)
 
         # 绘制状态条
         bar_draw = draw.InfoBarDraw()


### PR DESCRIPTION
修复 #249：PR #230 的部位名着色只读寸止计数 `orgasm_edge_count`，而时停期间的高潮积累写在 `time_stop_orgasm_count` 里，导致时停积累不着色。两者同为"快感越过阈值但尚未结算的绝顶次数"，故把着色读取改为两者之和。1 文件 +4/−3；无时停积累时求和结果与原值相同，寸止路径行为不变。

另排查了 issue 里的第二条线索（先寸止再转时停、计数凭空消失）：当前代码不会丢失——时停开启不清寸止计数，时停中结束 H 时状态重置对时停计数有显式保留（attr_calculation.py"时停绝顶保留"），解除时停时统一结算。故本 PR 仅含着色修复。

**证据**（Tk，同一存档同一操作序列，仅代码不同）：

| before（时停4次绝顶后，部位名灰白） | after（同路线，按次数着色） |
| --- | --- |
| [![时停积累后部位名保持灰白](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/before_status.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/before_status.png) | [![时停积累后部位名按次数着色](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/after_status.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/after_status.png) |
| [![阴道标签裁剪-灰白](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/before_label_crop.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/before_label_crop.png) | [![阴道标签裁剪-亮粉](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/after_label_crop.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/524c571b8f7526fa2eb66a8ef3e33c8292afeb7e/pr-fix-249-timestop-orgasm-color/after_label_crop.png) |


Fixes #249