### PR TITLE
fix: 一次渲染异常不该把 Tk 输出泵永久停掉

### DIFF
--- a/Script/Core/main_frame.py
+++ b/Script/Core/main_frame.py
@@ -472,12 +472,15 @@ def read_queue():
     finally:
         # 异常安全：无论是否抛异常都复位延迟标志，避免一次异常把滚动永久关掉
         _defer_see_end = False
+        # 排空或批末滚动抛出异常时也必须调度下一轮，否则输出泵停转、画面永久定格在最后一屏
+        # （异常本身不拦截，照常向 Tk 传播）
+        root.after(1, read_queue)
         if _see_end_pending:
+            # 先清标志再滚动：滚动若持续失败，标志滞留会让此后每一轮重排都再试一次
+            _see_end_pending = False
             # 本批确有输出请求过滚动，批末统一滚动一次；重绘由事件循环在下一空闲时刻自然完成，
             # 不显式冲刷 idle 队列（update_idletasks 会提前执行其他挂起的 idle 回调，产生越权副作用）
             see_end()
-            _see_end_pending = False
-    root.after(1, read_queue)
 
 
 def _read_queue_drain():


### PR DESCRIPTION
## 问题

`Script/Core/main_frame.py` 的 `read_queue()` 里，`root.after(1, read_queue)` 写在 `try/finally` **之外**：

```python
    try:
        _read_queue_drain()
    finally:
        _defer_see_end = False
        if _see_end_pending:
            see_end()
            _see_end_pending = False
    root.after(1, read_queue)      # ← 在 finally 之外
```

`_read_queue_drain()` 或批末 `see_end()` 只要抛出一次异常，这一句就不执行，**输出泵从此永久停转**：队列里后续消息再也不会被渲染，输入上膛标记也没人处理。玩家看到的是一屏完整正常的界面，点按钮只在输入行回显数字、回车无效，而 flow 线程其实还活着。异常是一次性的，代价却是整局卡死，并且没有任何提示。

## 触发路径：轻量版缺图

渲染图片的两处都是**无保护的字典下标**：

- `main_frame.py:563`（`_read_queue_drain` 内）：`era_image.image_data[json_data["image"]["image_name"]]`
- `main_frame.py:1013`（`io_print_image_cmd`，同样由 `_read_queue_drain` 调用）：`era_image.image_data[cmd_str]`

`era_image._LazyImageDict.__getitem__` 在图片不存在时 `raise KeyError(key)`；图片名来自开机时对 `image/` 目录的遍历，所以图片文件缺失就等于 KeyError。

而 `erArk_Lite` 发行包按 `.github/workflows/python-app.yml` 删掉了 `image/立绘`、`image/断面图`、`image/场景`。主场景的角色图片面板默认开启（`cache.scene_panel_show[4]` 初值为 `True`），走 `character_image.find_character_image_name()` → `draw.ImageButton`，该函数在所有候选都不存在时返回原名（注释即「都不存在则返回原始名（可能会导致图片显示失败）」）；口上里的 `{img:xxx}` 标签（`talk_image.draw_image_in_talk`）同理。

按上述删除规则手工裁剪 `image/` 目录后实测（未跑发行的 Lite zip）：

| 场景 | 异常 | 之后是否还能渲染 |
| --- | --- | --- |
| 缺 `image/断面图`，口上 `{img:标准状态}` | `KeyError('标准状态')` | 修改前：否 / 修改后：是 |
| 缺 `image/立绘`，主场景角色图片按钮 | `KeyError('阿米娅')` | 修改前：否 / 修改后：是 |

两种情况抛出的异常内容不变——本 PR 不拦截异常，只是让它不再连带把输出泵杀死。

## 修改

```python
    finally:
        _defer_see_end = False
        root.after(1, read_queue)      # ← 移进 finally，且置于可能抛异常的批末滚动之前
        if _see_end_pending:
            _see_end_pending = False   # ← 先清标志再滚动
            see_end()
```

两处位置都是必要的：

1. `root.after` 在 `finally` 内且**先于** `see_end()`：放在 `see_end()` 之后的话，批末滚动抛异常仍会跳过重排。
2. `_see_end_pending` **先清再滚动**：否则 `see_end()` 若持续失败，标志一直为真，每 1ms 的重排都会再试一次，把一次异常变成持续的异常刷屏。

不抛异常时行为与改动前完全一致：同一批仍只滚动一次，重排间隔仍是 1ms。
