### PR TITLE
[重要] 修复Tk模式下输入永久失效的问题

### DIFF
--- a/Script/Core/flow_handle.py
+++ b/Script/Core/flow_handle.py
@@ -550,3 +550,8 @@ def askfor_wait():
         re = askfor_str(donot_return_null_str=False)
         if re == "":
             break
+    # 等待结束后必须把标志位恢复为1
+    # 否则用回车结束等待时 w_frame_up 会遗留为0并跨界面残留（置1的唯一入口在鼠标路径上）
+    # 之后一次点在空白处的左键会被 mouse_left_check 的 w==0 分支误判为"推进等待"：
+    # 消耗掉一次性的输入许可却不产生任何指令，askfor_all 从此永远收不到输入，游戏静默卡死
+    cache.wframe_mouse.w_frame_up = 1

--- a/Script/Core/save_handle.py
+++ b/Script/Core/save_handle.py
@@ -417,6 +417,11 @@ def input_load_save(save_id: str):
     # 使用 update() 方法来更新 cache 的字典
     cache.__dict__.update(loaded_dict)
 
+    # 鼠标状态属于临时界面状态，不该随存档带入：旧版存档可能把“正在按任意键继续”的0值一起存了进来，
+    # 载入后 w_frame_up 残留为0，之后第一次左键会被 mouse_left_check 误判为“推进等待”，
+    # 消耗掉一次性的输入许可却不产生任何指令，askfor_all 从此收不到输入，游戏静默卡死
+    cache.wframe_mouse = game_type.WFrameMouse()
+
 
 def update_dict_with_default(loaded_dict, default_dict):
     """


### PR DESCRIPTION
### 问题

Tk 模式下的静默卡死：画面一切正常，但点任何按钮都只是把编号回显到输入行而不执行，回车也没有反应，控制台无任何报错，只能重启游戏。

### 根因

`cache.wframe_mouse.w_frame_up` 标记「当前是否停在按任意键继续」。`askfor_wait` 进入时清 0，用**鼠标点击**结束等待时由 `set_wframe_up` 置回 1，但用**回车**结束时没有任何代码恢复它，标志跨界面残留为 0。此后某次左键没点中按钮，`mouse_left_check` 便误以为玩家在推进一次文字等待：消耗掉一次性的输入许可（`input_armed = False`）却不提交任何指令，而逻辑线程此刻正阻塞在 `askfor_all` —— 死锁闭合，之后所有点击与回车都被挡在门外。

这个残留还会**跨存档传播**：`w_frame_up` 属于被 pickle 的 `cache`，玩家在残留状态下存盘，0 就写进了存档文件；之后读这份存档，`input_load_save` 把 0 一并装回内存，玩家读档后第一次落空的左键即刻锁死输入。

### 修复

1. `askfor_wait` 退出等待循环后统一把 `w_frame_up` 置 1，回车与鼠标两条结束路径都覆盖；
2. 读档后重建 `cache.wframe_mouse` —— 该结构的全部字段都是鼠标按键与逐字输出的瞬时状态，没有一项需要跨存档保留，重建即可救回已被污染的存档。

### 验证

纯上游代码、未启用任何 mod、Tk 模式、正向游玩。

先在本 PR 之前的版本上正常游玩（载入存档 → 点【1004 聊天】→ 用回车结束等待 → 存入空槽位），确认新写出的存档里 `w_frame_up == 0`；再用这份存档做前后对照：读档 → 在命令提示符行点一下（不是按钮）→ 点【002 查看属性】。

修复前（界面纹丝不动，输入行只残留回显的「2」）：

[![修复前](https://raw.githubusercontent.com/meower-z/erArk-fork/266bdadb829d05e25d4dde5215ad044881a3d9de/pr-266-save/before_stuck_after_load.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/266bdadb829d05e25d4dde5215ad044881a3d9de/pr-266-save/before_stuck_after_load.png)

修复后（同一存档、同一序列，属性界面正常打开）：

[![修复后](https://raw.githubusercontent.com/meower-z/erArk-fork/266bdadb829d05e25d4dde5215ad044881a3d9de/pr-266-save/after_panel_opens.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/266bdadb829d05e25d4dde5215ad044881a3d9de/pr-266-save/after_panel_opens.png)

我简单试玩验证过，目前功能正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
