### PR TITLE
修复：泡脚存放鞋袜时污浊记录不应被复制

### DIFF
--- a/Script/Settle/default_cloth.py
+++ b/Script/Settle/default_cloth.py
@@ -653,7 +653,7 @@ def handle_foot_cloth_to_shower_locker(
                     # print(f"debug move_cloth_id = {cloth_id}")
                     character_data.cloth.cloth_wear[clothing_type].remove(cloth_id)
                     character_data.cloth.cloth_locker_in_shower[clothing_type].append(cloth_id)
-        character_data.dirty.cloth_locker_semen[clothing_type] = character_data.dirty.cloth_semen[clothing_type]
+        character_data.dirty.cloth_semen[clothing_type], character_data.dirty.cloth_locker_semen[clothing_type] = character_data.dirty.cloth_locker_semen[clothing_type], character_data.dirty.cloth_semen[clothing_type]
     # 袜子和鞋子离开身体时去除对应部位上的避孕套装饰
     from Script.System.Item_System import condom_handle
     condom_handle.remove_cloth_decoration(character_id, [10, 11])


### PR DESCRIPTION
NPC 泡脚时把鞋袜存进更衣柜的结算里，袜子的污浊记录是逐键复制给衣柜、身上原样保留（同文件另两处衣柜转移都用交换写法），穿回时衣柜侧又合并回身上，污浊量翻倍。改为与另两处相同的交换写法（+1/-1）。