### PR TITLE
修复：（基建）岗位人员名单不再残留已离岛干员

### DIFF
--- a/Script/Design/basement.py
+++ b/Script/Design/basement.py
@@ -378,6 +378,12 @@ def update_work_people():
     cache.rhodes_island.trade_operator_ids_list = []
     for all_cid in game_config.config_work_type:
         cache.rhodes_island.all_work_npc_set[all_cid] = set()
+    # 重置各岗位当前人员名单，后续按在编角色重建
+    cache.rhodes_island.production_worker_ids = []
+    cache.rhodes_island.herb_garden_operator_ids = []
+    cache.rhodes_island.green_house_operator_ids = []
+    cache.rhodes_island.power_operator_ids_list = []
+    cache.rhodes_island.hr_operator_ids_list = []
 
     clinic_doctors = []
     hospital_doctors = []

--- a/Script/Design/basement.py
+++ b/Script/Design/basement.py
@@ -340,6 +340,8 @@ def update_base_resouce_newday():
     now_draw = draw.WaitDraw()
     now_draw.width = window_width
 
+    # 按当前在编角色重建岗位人员数据，供后续岗位结算使用
+    update_work_people()
     # 结算公务工作
     settle_office_work()
     # 结算精液转化


### PR DESCRIPTION
基建的五个岗位人员名单（生产工人、药田种植员、温室种植员、动力调控员、人事干员）是增量维护的：遍历在编干员做增删。干员离岛后不再被遍历，永远不会被移出名单——日结的流水线、农业、动力产量一直计入离岛者的加成，管理面板也照旧显示。

修复（`Script/Design/basement.py`，+8 行）：①名单重建时先置空再重建，离岛者自然消失；②这个重建此前只在打开管理面板时发生，现在每日结算开头也做一次，产量不再依赖玩家开面板刷新。刷新提前也让同函数里既有的岗位数据维护（如经外交派驻改职离岛干员的主生产工人槽撤销）在当日日结即生效，原本要等下次打开面板。

对比图（同一存档同一操作：任命可颂为副生产工人 → 外勤外派离岛 → 进入生产工人管理触发名单重建）。修复前：数量 1、可颂仍在列；修复后：数量 0、暂无：

[![修复前：离岛干员仍在生产工人名单](https://raw.githubusercontent.com/meower-z/erArk-fork/bcaa3d5fa5dadab8bdf8be38c9e7df95f955b653/pr-codex-fix-worker-lists-reset/before-workers-after-rebuild.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/bcaa3d5fa5dadab8bdf8be38c9e7df95f955b653/pr-codex-fix-worker-lists-reset/before-workers-after-rebuild.png)

[![修复后：名单重建正确排除离岛干员](https://raw.githubusercontent.com/meower-z/erArk-fork/bcaa3d5fa5dadab8bdf8be38c9e7df95f955b653/pr-codex-fix-worker-lists-reset/after-workers-after-rebuild.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/bcaa3d5fa5dadab8bdf8be38c9e7df95f955b653/pr-codex-fix-worker-lists-reset/after-workers-after-rebuild.png)