### PR TITLE
修复：（宿舍）结束临时住宿恢复宿舍时不再挤入已住满的房间

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -1631,8 +1631,8 @@ class Character:
         """ 角色所属办公室坐标 """
         self.dormitory: str = ""
         """ 角色宿舍坐标 """
-        self.pre_dormitory: str = ""
-        """ 角色前宿舍坐标 """
+        self.permanent_dormitory: str = ""
+        """ 角色的登记宿舍坐标：临时住进特殊房间期间记录其原普通宿舍；住在普通宿舍时恒为空 """
         self.birthday: datetime.datetime = datetime.datetime(1, 1, 1)
         """ 角色生日数据 """
         # self.chest_tem: int = 0

--- a/Script/Core/old_chara_to_new.py
+++ b/Script/Core/old_chara_to_new.py
@@ -716,7 +716,7 @@ def migrate_character_replacement(loaded_dict: dict, old_to_new_id_map: dict) ->
         # 位置数据
         new_character.position = old_character.position.copy() if old_character.position else ["0", "0"]
         new_character.officeroom = old_character.officeroom.copy() if hasattr(old_character, 'officeroom') and old_character.officeroom else []
-        new_character.pre_dormitory = old_character.pre_dormitory if hasattr(old_character, 'pre_dormitory') else ""
+        new_character.permanent_dormitory = getattr(old_character, "permanent_dormitory", getattr(old_character, "pre_dormitory", ""))
         
         # 时间相关
         new_character.birthday = old_character.birthday

--- a/Script/Core/save_handle.py
+++ b/Script/Core/save_handle.py
@@ -285,7 +285,10 @@ def _normalize_loaded_save_paths(loaded_cache: game_type.Cache) -> None:
         for character in character_data.values():
             if hasattr(character, "dormitory"):
                 character.dormitory = _normalize_save_path(character.dormitory)
-            if hasattr(character, "pre_dormitory"):
+            # 此处在 old_chara_to_new 迁移之前运行，可能遇到旧存档的 pre_dormitory 或新存档的 permanent_dormitory
+            if hasattr(character, "permanent_dormitory"):
+                character.permanent_dormitory = _normalize_save_path(character.permanent_dormitory)
+            elif hasattr(character, "pre_dormitory"):
                 character.pre_dormitory = _normalize_save_path(character.pre_dormitory)
             work_data = getattr(character, "work", None)
             if work_data is not None and hasattr(work_data, "dormitory_admin_target_room"):

--- a/Script/Design/character.py
+++ b/Script/Design/character.py
@@ -84,7 +84,6 @@ def init_attr(character_id: int):
         character_data.cloth = attr_calculation.get_cloth_zero()
         character_data.favorability = {0:0}
         character_data.dormitory = map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"]) # 此处不可使用翻译
-        character_data.pre_dormitory = map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"])
         # 初始收藏地点
         cache.collect_position_list = []
         cache.collect_position_list.append(['中枢', '博士房间'])

--- a/Script/Design/handle_premise/handle_premise_other.py
+++ b/Script/Design/handle_premise/handle_premise_other.py
@@ -2263,21 +2263,22 @@ def handle_jj_3(character_id: int) -> int:
 @add_premise(constant_promise.Premise.CAN_MANUAL_CHANGE_DORMITORY)
 def handle_can_manual_change_dormitory(character_id: int) -> int:
     """
-    该角色当前可被手动更换宿舍（未处于同居/监禁/监狱长/异常7等特殊状态）
+    该角色当前可被手动更换宿舍（未处于监禁/同居/舍管/监狱长等特殊住宿状态，且未离线（外勤、装袋搬走、婴儿、外交访问、逃跑中））
     Keyword arguments:
     character_id -- 角色id
     Return arguments:
     int -- 权重
     """
     from Script.Design.handle_premise import handle_normal_7
+    from Script.System.Dormitory_System import common as dormitory_common
     character_data: game_type.Character = cache.character_data[character_id]
-    # pre_dormitory 非空且与 dormitory 不同，说明正处于助理同居或监禁中
-    if character_data.pre_dormitory != "" and character_data.pre_dormitory != character_data.dormitory:
+    # 处于特殊住宿状态（监禁/同居/舍管/监狱长）的角色不允许手动换宿
+    if dormitory_common.get_residence_type(character_id) != "dormitory":
         return 0
     # 玩家角色本身不允许手动换宿
     if character_id == 0:
         return 0
-    # 异常为7的角色不允许换宿舍
+    # 离线（外勤、装袋搬走、婴儿、外交访问、逃跑中）的角色不允许换宿舍
     if not handle_normal_7(character_id):
         return 0
     return 1

--- a/Script/Settle/default.py
+++ b/Script/Settle/default.py
@@ -7691,10 +7691,9 @@ def handle_set_free_add_just(
     target_data: game_type.Character = cache.character_data[character_data.target_character_id]
     target_data.sp_flag.imprisonment = False
     handle_premise.settle_chara_unnormal_flag(character_data.target_character_id, 2)
+    from Script.System.Dormitory_System import common as dormitory_common
     # 回到旧宿舍
-    if target_data.pre_dormitory != "":
-        target_data.dormitory = target_data.pre_dormitory
-        target_data.pre_dormitory = ""
+    dormitory_common.restore_character_dormitory(character_data.target_character_id)
     # 从囚犯数据中删除
     if character_data.target_character_id in cache.rhodes_island.current_prisoners:
         cache.rhodes_island.current_prisoners.pop(character_data.target_character_id)

--- a/Script/System/Dormitory_System/common.py
+++ b/Script/System/Dormitory_System/common.py
@@ -180,17 +180,62 @@ def get_open_dormitory_room_occupancy() -> Dict[str, int]:
     return room_occupancy
 
 
-def pick_dormitory_room(room_occupancy: Dict[str, int]) -> str:
+def pick_dormitory_room(room_occupancy: Dict[str, int], preferred_room: str = "") -> str:
     """
     纯函数：按占用表挑选新入住者应分配的宿舍
     输入类型: room_occupancy(Dict[str, int]) -- 按层序排列的开放普通宿舍占用表，键为房间路径，值为当前人数
+    输入类型: preferred_room(str) -- 入住者的优先意向房间（如角色的登记宿舍）路径，默认为空表示无意向
     输出类型: str
-    功能: 宿舍设计容量为2人，返回表中第一间不足2人的房间；全部住满时返回人数最少的一间（并列时取顺序最前者）
+    功能: 宿舍设计容量为2人，优先房在表内且不足2人时直接入住；否则返回表中第一间不足2人的房间；全部住满时返回人数最少的一间（并列时取顺序最前者）
     """
+    if preferred_room in room_occupancy and room_occupancy[preferred_room] < 2:
+        return preferred_room
     for room_path, count in room_occupancy.items():
         if count < 2:
             return room_path
     return min(room_occupancy, key=room_occupancy.get)
+
+
+def get_residence_type(character_id: int) -> str:
+    """
+    获取角色当前的特殊住宿类型
+    输入类型: character_id(int)
+    输出类型: str
+    功能: 按访客>监禁>同居>舍管>监狱长的顺序返回角色命中的首个特殊住宿类型（"guest_room"/"prison"/"with_player"/"dormitory_manager"/"prison_manager"）；未处于任何特殊住宿状态时返回"dormitory"（正常住宿）
+    """
+    character_data: game_type.Character = cache.character_data[character_id]
+    # 访客，住在访客区客房
+    if character_id in cache.rhodes_island.visitor_info:
+        return "guest_room"
+    # 被监禁
+    if character_data.sp_flag.imprisonment:
+        return "prison"
+    # 开启同居服务的助理，住在博士房间
+    if character_data.assistant_services[7] == 1:
+        return "with_player"
+    # 宿舍管理员，包住宿岗位
+    if character_data.work.work_type == 31:
+        return "dormitory_manager"
+    # 监狱长，包住宿岗位
+    if character_data.work.work_type == 191:
+        return "prison_manager"
+    return "dormitory"
+
+
+def restore_character_dormitory(character_id: int) -> str:
+    """
+    结束临时住宿状态时恢复角色的宿舍归属
+    输入类型: character_id(int)
+    输出类型: str
+    功能: 确保角色住回开放普通宿舍：已住在开放普通宿舍则保持不变；否则按登记宿舍优先分配（登记宿舍有空床则回住，无则按新入住规则挑选）。随后清空 permanent_dormitory（角色住在普通宿舍时该字段恒为空），返回最终宿舍路径
+    """
+    character_data: game_type.Character = cache.character_data[character_id]
+    room_occupancy = get_open_dormitory_room_occupancy()
+    # 已住在开放普通宿舍则无需重新分配；否则按登记宿舍优先挑选新房
+    if character_data.dormitory not in room_occupancy:
+        character_data.dormitory = pick_dormitory_room(room_occupancy, character_data.permanent_dormitory)
+    character_data.permanent_dormitory = ""
+    return character_data.dormitory
 
 
 def get_dormitory_occupants_text() -> str:

--- a/Script/System/Dormitory_System/common.py
+++ b/Script/System/Dormitory_System/common.py
@@ -203,21 +203,21 @@ def get_residence_type(character_id: int) -> str:
     输出类型: str
     功能: 按访客>监禁>同居>舍管>监狱长的顺序返回角色命中的首个特殊住宿类型（"guest_room"/"prison"/"with_player"/"dormitory_manager"/"prison_manager"）；未处于任何特殊住宿状态时返回"dormitory"（正常住宿）
     """
-    character_data: game_type.Character = cache.character_data[character_id]
+    from Script.Design import handle_premise
     # 访客，住在访客区客房
-    if character_id in cache.rhodes_island.visitor_info:
+    if handle_premise.handle_self_visitor_flag_1(character_id):
         return "guest_room"
     # 被监禁
-    if character_data.sp_flag.imprisonment:
+    if handle_premise.handle_imprisonment_1(character_id):
         return "prison"
     # 开启同居服务的助理，住在博士房间
-    if character_data.assistant_services[7] == 1:
+    if handle_premise.handle_assistant_live_together_on(character_id):
         return "with_player"
     # 宿舍管理员，包住宿岗位
-    if character_data.work.work_type == 31:
+    if handle_premise.handle_work_is_dormitory_manager(character_id):
         return "dormitory_manager"
     # 监狱长，包住宿岗位
-    if character_data.work.work_type == 191:
+    if handle_premise.handle_work_is_warden(character_id):
         return "prison_manager"
     return "dormitory"
 

--- a/Script/System/Dormitory_System/manage_dormitory_panel.py
+++ b/Script/System/Dormitory_System/manage_dormitory_panel.py
@@ -431,7 +431,7 @@ class Manage_Dormitory_Panel:
         应用角色宿舍变更
         输入类型: character_id(int), dormitory_path(str)
         输出类型: 无
-        功能: 更新角色 dormitory 字段，不修改 pre_dormitory
+        功能: 更新角色 dormitory 字段，不修改 permanent_dormitory
         """
         character_data = cache.character_data[character_id]
         old_text = self._get_dormitory_name(character_data.dormitory)
@@ -849,8 +849,8 @@ class Manage_Dormitory_Panel:
             return
 
         character_data = cache.character_data[character_id]
-        if not self._is_manager_room_path(character_data.dormitory) and character_data.pre_dormitory == "":
-            character_data.pre_dormitory = character_data.dormitory
+        if not self._is_manager_room_path(character_data.dormitory) and character_data.permanent_dormitory == "":
+            character_data.permanent_dormitory = character_data.dormitory
         character_data.dormitory = manager_room_path
 
         character_position = character_data.position
@@ -863,25 +863,14 @@ class Manage_Dormitory_Panel:
         将被撤销任命的宿舍管理员恢复原宿舍
         输入类型: character_id(int)
         输出类型: 无
-        功能: 若角色当前在舍管房且存在 pre_dormitory，则恢复到原宿舍并清空 pre_dormitory
+        功能: 若角色当前住在舍管房，则按恢复规则重新分配宿舍，并将其移动到落点房间
         """
-        if character_id not in cache.character_data:
-            return
-
         character_data = cache.character_data[character_id]
         if not self._is_manager_room_path(character_data.dormitory):
             return
-        if character_data.pre_dormitory == "":
-            return
-
-        restore_path = character_data.pre_dormitory
-        character_data.dormitory = restore_path
-        character_data.pre_dormitory = ""
-
-        character_position = character_data.position
+        restore_path = common.restore_character_dormitory(character_id)
         target_scene = map_handle.get_map_system_path_for_str(restore_path)
-        if target_scene:
-            map_handle.character_move_scene(character_position, target_scene, character_id)
+        map_handle.character_move_scene(character_data.position, target_scene, character_id)
 
     def _get_dormitory_max_open_layer(self) -> int:
         """

--- a/Script/UI/Panel/assistant_panel.py
+++ b/Script/UI/Panel/assistant_panel.py
@@ -107,7 +107,8 @@ def assistant_replace(new_assistant_id: int):
         handle_premise.settle_chara_unnormal_flag(character_data.assistant_character_id, 3)
         # 去掉旧助理的同居状态
         if character_data.assistant_character_id != 0 and old_assistant_data.dormitory == map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"]):
-            old_assistant_data.dormitory = old_assistant_data.pre_dormitory
+            from Script.System.Dormitory_System import common as dormitory_common
+            dormitory_common.restore_character_dormitory(character_data.assistant_character_id)
         # 重置旧助理的助理服务数据体
         old_assistant_data.assistant_services = attr_calculation.get_assistant_services_zero()
     # 没有旧助理
@@ -354,10 +355,11 @@ class Assistant_Panel:
             # 此处不可以用翻译地点
             if service_cid == 7:
                 if target_data.assistant_services[service_cid] == 1:
-                    target_data.pre_dormitory = target_data.dormitory
+                    target_data.permanent_dormitory = target_data.dormitory
                     target_data.dormitory = map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"])
                 elif target_data.dormitory == map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"]):
-                    target_data.dormitory = target_data.pre_dormitory
+                    from Script.System.Dormitory_System import common as dormitory_common
+                    dormitory_common.restore_character_dormitory(character_data.assistant_character_id)
                 # print(f"debug target_data.dormitory = {target_data.dormitory}")
 
     def select_morning_salutation_time(self):

--- a/Script/UI/Panel/confinement_and_training.py
+++ b/Script/UI/Panel/confinement_and_training.py
@@ -199,8 +199,8 @@ def chara_become_prisoner(character_id: int):
     # 服装结算
     clothing.handle_prisoner_clothing(character_id)
     # 当前位置作为宿舍，并保存旧宿舍
-    if character_data.pre_dormitory == "":
-        character_data.pre_dormitory = character_data.dormitory
+    if character_data.permanent_dormitory == "":
+        character_data.permanent_dormitory = character_data.dormitory
     character_data.dormitory = map_handle.get_map_system_path_str_for_list(character_data.position)
     # 给予屈服2，恐怖1，反发3，但如果有隶属系陷落，则可以减轻该效果
     target_fall = attr_calculation.get_character_fall_level(character_id, minus_flag=True)

--- a/Script/UI/Panel/manage_basement_panel.py
+++ b/Script/UI/Panel/manage_basement_panel.py
@@ -1336,10 +1336,11 @@ class Change_Npc_Work_Panel:
             for i in target_data.body_manage:
                 if i in range(30,40) and target_data.body_manage[i]:
                     target_data.body_manage[i] = 0
+        from Script.System.Dormitory_System import common
         # 如果旧的工作是监狱长，则解除监狱长身份，并重置宿舍
         if handle_premise.handle_work_is_warden(character_id):
             target_data.work.work_type = 0
-            target_data.dormitory = target_data.pre_dormitory
+            common.restore_character_dormitory(character_id)
             cache.rhodes_island.current_warden_id = 0
         # 赋予新工作
         target_data.work.work_type = work_id
@@ -1350,11 +1351,11 @@ class Change_Npc_Work_Panel:
             if cache.rhodes_island.current_warden_id != 0 and cache.rhodes_island.current_warden_id != character_id:
                 old_warden_data: game_type.Character = cache.character_data[cache.rhodes_island.current_warden_id]
                 old_warden_data.work.work_type = 0
-                old_warden_data.dormitory = old_warden_data.pre_dormitory
+                common.restore_character_dormitory(cache.rhodes_island.current_warden_id)
             # 更新监狱长id
             cache.rhodes_island.current_warden_id = character_id
             # 更新监狱长的宿舍
-            target_data.pre_dormitory = target_data.dormitory
+            target_data.permanent_dormitory = target_data.dormitory
             target_data.dormitory = map_handle.get_map_system_path_str_for_list(["关押", "休息室"])
         # 更新罗德岛的工作人员及状态
         basement.update_work_people()


### PR DESCRIPTION
角色退出特殊迁入状态（关闭助理同居、撤销宿舍管理员/监狱长、监禁释放等）恢复宿舍时，直接设回之前保存的房间、不查那间房现在是否还有空床。迁入期间原床位在宿舍总览里显示为空床、可以被合法调入其他干员，此后退出迁入就会三人挤两床。现把全部六处恢复调用点统一收进一个共享函数：角色已住在开放普通宿舍则保持不变；原宿舍仍有空床则照旧回原宿舍；已住满时复用 #299 的入住规则重新分配——按房号从小到大分进第一间有空床的开放宿舍，全部住满时分入人数最少的一间。（#237 修复的是外勤离岛路径的床位统计；本处是特殊迁入结束时的恢复路径，是其未覆盖的另一条进路。）

同时把 `pre_dormitory` 字段更名为 `permanent_dormitory`，明确其语义为「登记宿舍」：角色临时住进特殊房间期间记录其原普通宿舍，住在普通宿舍时恒为空。旧存档的字段名在读档迁移与路径归一化阶段兼容处理；玩家角色初始化不再向该字段写入博士房间（该写入违反上述语义，且无消费方依赖）。

「可否手动换宿」的前提判定原本从该字段反推「处于同居或监禁中」，既列举不全（舍管、监狱长同样包住宿）也依赖字段状态间接推断；现改为新增的 `get_residence_type()` 按各状态自身的直接标志判定（访客/监禁/同居/舍管/监狱长），访客与已任命的舍管、监狱长现在也会被正确挡下。

对比图（同一存档同一操作：先手动把夜莺的原宿舍 116 房合法住满两人，再关闭助理同居，打开宿舍总览；总览人数栏分母取「2 与当前人数的较大者」，超员房因此显示 (3/3) 而非 (3/2)）。修复前：夜莺被挤回已满的 116 房变 (3/3)，106 房空床闲置；修复后：116 房保持 (2/2)，夜莺分入首个有空床的 106 房：

[![修复前：夜莺被挤回已满的116房变(3/3)](https://raw.githubusercontent.com/meower-z/erArk-fork/f01286e24842ab2ff25fd34784b3e7799f6efbff/pr-codex-fix-dormitory-restore/before-restore-overcrowd-116.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/f01286e24842ab2ff25fd34784b3e7799f6efbff/pr-codex-fix-dormitory-restore/before-restore-overcrowd-116.png)

[![修复后：116房保持(2/2)，夜莺分入106房空床](https://raw.githubusercontent.com/meower-z/erArk-fork/f01286e24842ab2ff25fd34784b3e7799f6efbff/pr-codex-fix-dormitory-restore/after-restore-into-106.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/f01286e24842ab2ff25fd34784b3e7799f6efbff/pr-codex-fix-dormitory-restore/after-restore-into-106.png)
