### PR TITLE
修复：（AI行为）博士尿意较高时干员不再随机给博士泡咖啡

### DIFF
--- a/Script/Core/constant_promise.py
+++ b/Script/Core/constant_promise.py
@@ -1115,6 +1115,8 @@
     """ 属性_基础 尿意条≥150%，需要当场排尿 """
     TARGET_URINATE_LE_49 = "t_urinate_le_49"
     """ 属性_基础 交互对象尿意条≤49%，可以继续喝咖啡 """
+    PL_URINATE_LE_49 = "pl_urinate_le_49"
+    """ 属性_基础 玩家尿意条≤49%，可以继续喝咖啡 """
     TARGET_URINATE_LE_79 = "t_urinate_le_79"
     """ 属性_基础 交互对象尿意条≤79%，不需要排尿 """
     TARGET_URINATE_GE_80 = "t_urinate_ge_80"

--- a/Script/Design/handle_premise/handle_premise_base_value.py
+++ b/Script/Design/handle_premise/handle_premise_base_value.py
@@ -735,6 +735,24 @@ def handle_target_urinate_le_49(character_id: int) -> int:
         return 0
 
 
+@add_premise(constant_promise.Premise.PL_URINATE_LE_49)
+def handle_pl_urinate_le_49(character_id: int) -> int:
+    """
+    玩家尿意条≤49%，可以继续喝咖啡
+    Keyword arguments:
+    character_id -- 角色id
+    Return arguments:
+    int -- 权重
+    """
+    player_data: game_type.Character = cache.character_data[0]
+
+    value = player_data.urinate_point / 240
+    if value <= 0.49:
+        return 1
+    else:
+        return 0
+
+
 @add_premise(constant_promise.Premise.TARGET_URINATE_LE_79)
 def handle_target_urinate_le_79(character_id: int) -> int:
     """

--- a/data/target/default/target.csv
+++ b/data/target/default/target.csv
@@ -32,7 +32,7 @@ ai的目标,,,,
 
 30100,100,normal_1267|place_0|player_can_be_interact,3,1267正常（可能AI跟随、服装异常或意识模糊），和玩家在一个房间里，玩家当前可被交互，则有可能随机和玩家聊天
 30105,101,self_fall|normal_1267|place_0|player_can_be_interact,3,自己有陷落素质，1267正常（可能AI跟随、服装异常或意识模糊），和玩家在一个房间里，玩家当前可被交互，则有可能随机和玩家身体接触
-30110,102,self_fall|normal_1267|place_0|player_can_be_interact|place_furniture_ge_2,3,自己有陷落素质，1267正常（可能AI跟随、服装异常或意识模糊），和玩家在一个房间里，玩家当前可被交互，当前地点至少有办公级家具，则有可能随机给玩家泡咖啡
+30110,102,self_fall|normal_1267|place_0|player_can_be_interact|place_furniture_ge_2|pl_urinate_le_49,3,自己有陷落素质，1267正常（可能AI跟随、服装异常或意识模糊），和玩家在一个房间里，玩家当前可被交互，当前地点至少有办公级家具，玩家尿意条≤49%，则有可能随机给玩家泡咖啡
 30200,200,normal_1267|scene_someone_can_be_interact,3,1267正常（可能AI跟随、服装异常或意识模糊），场景内存在可交互对象，则可能随机和房间里的人聊天
 30205,201,normal_1267|scene_someone_can_be_interact,3,1267正常（可能AI跟随、服装异常或意识模糊），场景内存在可交互对象，则可能随机和房间里的人身体接触
 30210,202,normal_1267|in_music_room|scene_someone_can_be_interact,3,1267正常（可能AI跟随、服装异常或意识模糊），在音乐室里，场景内存在可交互对象，则唱歌给房间里随机角色听

--- a/tools/ArkEditor/csv/Premise.csv
+++ b/tools/ArkEditor/csv/Premise.csv
@@ -556,6 +556,7 @@ urinate_le_79,URINATE_LE_79,属性_基础,尿意条≤79%，不需要排尿
 urinate_ge_80,URINATE_GE_80,属性_基础,尿意条≥80%，需要排尿
 urinate_ge_125,URINATE_GE_125,属性_基础,尿意条≥150%，需要当场排尿
 t_urinate_le_49,TARGET_URINATE_LE_49,属性_基础,交互对象尿意条≤49%，可以继续喝咖啡
+pl_urinate_le_49,PL_URINATE_LE_49,属性_基础,玩家尿意条≤49%，可以继续喝咖啡
 t_urinate_le_79,TARGET_URINATE_LE_79,属性_基础,交互对象尿意条≤79%，不需要排尿
 t_urinate_ge_80,TARGET_URINATE_GE_80,属性_基础,交互对象尿意条≥80%，需要排尿
 hunger_le_20,HUNGER_LE_20,属性_基础,饥饿值≤20%，很饱


### PR DESCRIPTION
陷落干员与博士同处一室时可能随机主动给博士泡咖啡（`data/target/default/target.csv` 的 cid 30110），准入前提不检查博士的尿意；而同一件事的两条指令入口「泡咖啡」「让对方泡咖啡」都要求喝的一方尿意条≤49%。博士尿意再高，干员仍会端来咖啡，喝下后尿意又涨 60 点（按尿意条上限 240 计约 25%）。

既有的「交互对象尿意条≤49%」前提（两条指令在用的门）在这里不能直接复用：AI 目标筛选阶段求值前提时尚未把博士设为交互对象（选中后状态机内才写入），经交互对象取值读到的是旧值。故新增直接读玩家本人数值的通用前提 `pl_urinate_le_49`，阈值与换算与既有门完全一致，追加到 cid 30110 的前提串，并在 ArkEditor 的 Premise.csv 同步登记。只收紧这一条准入；博士尿意回落到 49% 以下后行为照旧。

对比图（同一存档、相同的随机种子、两侧执行相同的等待序列）。修复前：第 30 次等待后夜莺给博士泡咖啡并完成全套结算；修复后：同一时点无泡咖啡，夜莺转为正常替代行为（柔韧性训练心得）。判据时点玩家尿意超过门槛可由帧内自证：指令面板可见「解手」按钮，其显示前提要求尿意≥80%：

[![修复前：夜莺给博士泡咖啡并完成结算](https://raw.githubusercontent.com/meower-z/erArk-fork/2e83c3d28ca77037b8db2556eb664a182bca24a7/pr-codex-fix-coffee-urinate-gate/before_baseline_wait30_nightingale_coffee.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/2e83c3d28ca77037b8db2556eb664a182bca24a7/pr-codex-fix-coffee-urinate-gate/before_baseline_wait30_nightingale_coffee.png)

[![修复后：同一时点无泡咖啡](https://raw.githubusercontent.com/meower-z/erArk-fork/2e83c3d28ca77037b8db2556eb664a182bca24a7/pr-codex-fix-coffee-urinate-gate/after_candidate_wait30_no_coffee.png)](https://raw.githubusercontent.com/meower-z/erArk-fork/2e83c3d28ca77037b8db2556eb664a182bca24a7/pr-codex-fix-coffee-urinate-gate/after_candidate_wait30_no_coffee.png)
