### PR TITLE
修复：（睡眠）睡眠结算写入熟睡值时钳制在合法范围内

### DIFF
--- a/Script/Settle/realtime_settle.py
+++ b/Script/Settle/realtime_settle.py
@@ -425,7 +425,7 @@ def settle_sleep(character_id: int, true_add_time: int) -> None:
         handle_premise.handle_self_not_sleep_pills(character_id) and
         handle_premise.handle_drunk_level_0(character_id)
     ):
-        now_char.sleep_point = max(now_char.sleep_point - add_sleep, 0)
+        now_char.sleep_point = min(max(now_char.sleep_point - add_sleep, 0), 100)
         # 熟睡值已减少到0时NPC直接醒来
         if now_char.sleep_point <= 0 and character_id:
             pl_character_data: game_type.Character = cache.character_data[0]
@@ -449,7 +449,7 @@ def settle_sleep(character_id: int, true_add_time: int) -> None:
             return
     # 其他情况下正常增加熟睡值
     else:
-        now_char.sleep_point = min(now_char.sleep_point + add_sleep, 100)
+        now_char.sleep_point = min(max(now_char.sleep_point + add_sleep, 0), 100)
     handle_premise.settle_chara_unnormal_flag(character_id, 5)
     handle_premise.settle_chara_unnormal_flag(character_id, 6)
     # 回复体力和气力


### PR DESCRIPTION
睡眠结算中熟睡值的单段变化量是一个可正可负的随机数，但两个写入点各只钳了一个方向：夜间开始的睡眠恒走「只有上限 100」的分支，玩家一觉 6–8 小时会给每名在睡干员一次数百分钟的单段结算，负向波动足以把熟睡值从满值减穿 0（实机出现过 −22）；另一个分支反向运算时同理可以顶过 100。负值不显示、醒来也不重置，会跟着角色一整个白天，实际后果是唤醒判定（60 − 熟睡值）把刚睡足的深眠角色算成一碰必醒。

现把两个写入点都改为双向钳制，保证熟睡值始终落在 [0,100]：未越界的取值完全不受影响，越界样本被截在边界上。
