### PR TITLE
修复：（怀孕）成长加速药等的预计日期显示错误

### DIFF
--- a/Script/Design/game_time.py
+++ b/Script/Design/game_time.py
@@ -214,6 +214,26 @@ def get_sub_date(
     return new_date
 
 
+def get_predict_date(day: int, old_date: datetime.datetime) -> datetime.datetime:
+    """
+    获取旧日期经过指定天数后、游戏时钟真正会走到的日期，用于各类"预计X日"的展示\n
+    游戏一年只有3/6/9/12四个季月，非季月会被时钟整段跳过（见 sub_time_now 的切月归1处理），
+    因此目标日期落在被跳过的月份时，取其之后第一个季月的1日；
+    直接用 get_sub_date 会保留被跳过月份的"日"再把月份改成季月，得到时钟永远不会显示的日期，
+    并且随天数减少反而可能显示成更晚的日期
+    Keyword arguments:
+    day -- 经过的天数
+    old_date -- 起始日期
+    Return arguments:
+    datetime.datetime -- 预计日期
+    """
+    predict_date = old_date + datetime.timedelta(days=day)
+    season_month = get_season_month(predict_date.month)
+    if season_month == predict_date.month:
+        return predict_date
+    return predict_date.replace(month=season_month, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
 def get_rand_day_for_year(year: int) -> datetime.datetime:
     """
     随机获取指定年份中一天的日期

--- a/Script/System/Pregnancy_System/pregnancy_panel.py
+++ b/Script/System/Pregnancy_System/pregnancy_panel.py
@@ -92,7 +92,7 @@ def get_stage_info_text(character_id: int, now_stage: int) -> str:
         start_time = character_data.pregnancy.fertilization_time
         # 预计日期扣除妊娠加速药的加速天数，已到期则显示为当天
         acc_day = int(character_data.pregnancy.acceleration_days)
-        predict_time = max(game_time.get_sub_date(day=pregnancy_constant.PREGNANCY_DAY - acc_day, old_date=start_time), cache.game_time)
+        predict_time = max(game_time.get_predict_date(pregnancy_constant.PREGNANCY_DAY - acc_day, start_time), cache.game_time)
         return _("受精于{0}，预计{1}妊娠").format(get_date_text(start_time), get_date_text(predict_time)) + get_fetus_count_text(character_id)
     if now_stage == pregnancy_constant.STAGE_EGG_WAIT:
         egg_count = len(egg_handle.get_unidentified_eggs(character_id, exclude_held=False))
@@ -112,7 +112,7 @@ def get_stage_info_text(character_id: int, now_stage: int) -> str:
         start_time = character_data.pregnancy.fertilization_time
         # 预计日期扣除妊娠加速药的加速天数，已到期则显示为当天
         acc_day = int(character_data.pregnancy.acceleration_days)
-        predict_time = max(game_time.get_sub_date(day=pregnancy_constant.PARTURIENT_DAY - acc_day, old_date=start_time), cache.game_time)
+        predict_time = max(game_time.get_predict_date(pregnancy_constant.PARTURIENT_DAY - acc_day, start_time), cache.game_time)
         return _("受精于{0}，预计{1}临盆").format(get_date_text(start_time), get_date_text(predict_time)) + get_fetus_count_text(character_id)
     if now_stage == pregnancy_constant.STAGE_HATCHING:
         hatching_eggs = egg_handle.get_hatching_eggs(character_id)
@@ -120,7 +120,7 @@ def get_stage_info_text(character_id: int, now_stage: int) -> str:
         hatch_day = egg_handle.get_hatch_day(first_egg)
         # 预计破壳日扣除孵化加速药的加速天数，已到期则显示为当天
         egg_acc_day = int(first_egg.get("acceleration_days", 0))
-        born_time = max(game_time.get_sub_date(day=pregnancy_constant.HATCH_TOTAL_DAY - egg_acc_day, old_date=first_egg["lay_time"]), cache.game_time)
+        born_time = max(game_time.get_predict_date(pregnancy_constant.HATCH_TOTAL_DAY - egg_acc_day, first_egg["lay_time"]), cache.game_time)
         return _("孵化第{0}天，预计{1}破壳").format(hatch_day, get_date_text(born_time))
     if now_stage == pregnancy_constant.STAGE_PARTURIENT:
         return _("已在住院区待产，预计近日生产") + get_fetus_count_text(character_id)
@@ -134,7 +134,7 @@ def get_stage_info_text(character_id: int, now_stage: int) -> str:
         for child_id in pregnancy_handle.get_baby_id_list(character_id):
             child_data = cache.character_data[child_id]
             acc_day = int(getattr(child_data.pregnancy, "growth_acceleration_days", 0))
-            grow_time = max(game_time.get_sub_date(day=pregnancy_constant.REARING_COMPLETE_DAY - acc_day, old_date=child_data.pregnancy.born_time), cache.game_time)
+            grow_time = max(game_time.get_predict_date(pregnancy_constant.REARING_COMPLETE_DAY - acc_day, child_data.pregnancy.born_time), cache.game_time)
             baby_text_list.append(_("{0}（预计{1}长大）").format(child_data.name, get_date_text(grow_time)))
         if len(baby_text_list):
             return _("正在育儿室照顾{0}").format("、".join(baby_text_list))

--- a/Script/UI/Panel/gift_panel.py
+++ b/Script/UI/Panel/gift_panel.py
@@ -72,7 +72,7 @@ def handle_drug_use_effect(character_id: int, drug_id: int):
             character_data.pregnancy.acceleration_days += add_day
             now_acc = int(character_data.pregnancy.acceleration_days)
             # 预计日期用游戏时间函数计算，自动归并到四季月
-            predict_time = game_time.get_sub_date(day=pregnancy_constant.PARTURIENT_DAY - now_acc, old_date=character_data.pregnancy.fertilization_time)
+            predict_time = game_time.get_predict_date(pregnancy_constant.PARTURIENT_DAY - now_acc, character_data.pregnancy.fertilization_time)
             now_draw.text += _("本次加速{0}天，累计加速{1}天，{2}的预计临盆日期提前到了{3}\n").format(int(add_day), now_acc, character_data.name, pregnancy_panel.get_date_text(predict_time))
         else:
             # 兜底：结算时已到加速极限则不生效（正常已被送出前校验拦截）
@@ -91,7 +91,7 @@ def handle_drug_use_effect(character_id: int, drug_id: int):
             if add_day > 0:
                 egg_data["acceleration_days"] = egg_data.get("acceleration_days", 0) + add_day
                 now_acc = int(egg_data["acceleration_days"])
-                predict_time = game_time.get_sub_date(day=pregnancy_constant.HATCH_TOTAL_DAY - now_acc, old_date=egg_data["lay_time"])
+                predict_time = game_time.get_predict_date(pregnancy_constant.HATCH_TOTAL_DAY - now_acc, egg_data["lay_time"])
                 now_draw.text += _("本次加速{0}天，累计加速{1}天，这枚卵的预计破壳日期提前到了{2}\n").format(int(add_day), now_acc, pregnancy_panel.get_date_text(predict_time))
             else:
                 now_draw.text += _("这枚卵已经加速到极限，药物没有产生效果\n")
@@ -123,7 +123,7 @@ def handle_drug_use_effect(character_id: int, drug_id: int):
                 child_character_data.pregnancy.growth_acceleration_days = getattr(child_character_data.pregnancy, "growth_acceleration_days", 0) + add_day
                 now_acc = int(child_character_data.pregnancy.growth_acceleration_days)
                 total_day = pregnancy_handle.get_child_growth_stage_total_day(child_id)
-                predict_time = game_time.get_sub_date(day=total_day - now_acc, old_date=child_character_data.pregnancy.born_time)
+                predict_time = game_time.get_predict_date(total_day - now_acc, child_character_data.pregnancy.born_time)
                 now_draw.text += _("本次加速{0}天，累计加速{1}天，{2}预计将在{3}成长为{4}\n").format(int(add_day), now_acc, child_character_data.name, pregnancy_panel.get_date_text(predict_time), next_stage_name)
             else:
                 now_draw.text += _("{0}已经快要成长为{1}了，药物没有产生效果\n").format(child_character_data.name, next_stage_name)
@@ -308,7 +308,7 @@ class Gift_Panel:
             for egg_id, egg_data in accelerable_eggs.items():
                 hatch_day = egg_handle.get_hatch_day(egg_data)
                 acc_day = int(egg_data.get("acceleration_days", 0))
-                born_time = game_time.get_sub_date(day=pregnancy_constant.HATCH_TOTAL_DAY - acc_day, old_date=egg_data["lay_time"])
+                born_time = game_time.get_predict_date(pregnancy_constant.HATCH_TOTAL_DAY - acc_day, egg_data["lay_time"])
                 egg_text = _("[{0}号卵] 孵化第{1}天（已加速{2}天，预计{3}破壳）").format(egg_id, hatch_day, acc_day, pregnancy_panel.get_date_text(born_time))
                 button_draw = draw.LeftButton(
                     egg_text,
@@ -365,7 +365,7 @@ class Gift_Panel:
                 child_character_data: game_type.Character = cache.character_data[child_id]
                 grow_day = pregnancy_handle.get_child_grow_day(child_id)
                 acc_day = int(getattr(child_character_data.pregnancy, "growth_acceleration_days", 0))
-                grow_time = game_time.get_sub_date(day=pregnancy_constant.REARING_COMPLETE_DAY - acc_day, old_date=child_character_data.pregnancy.born_time)
+                grow_time = game_time.get_predict_date(pregnancy_constant.REARING_COMPLETE_DAY - acc_day, child_character_data.pregnancy.born_time)
                 baby_text = _("[{0}] 出生第{1}天（已加速{2}天，预计{3}成长为幼女）").format(child_character_data.name, grow_day, acc_day, pregnancy_panel.get_date_text(grow_time))
                 button_draw = draw.LeftButton(
                     baby_text,


### PR DESCRIPTION
游戏一年只有 3/6/9/12 四个季月，其余月份被时钟整段跳过。妊娠/临盆/破壳/成长各处「预计X日」用 `get_sub_date` 计算，它保留了被跳过月份的「日」、只把月份改成季月，得到的是时钟永远不会走到的日期；连续使用成长加速药时，剩余天数在减少，显示的日期反而会变晚再跳回（春月3日出生的婴儿，剩余 90/63/45/31 天分别显示为夏月1日/夏月5日/夏月17日/夏月3日，实际结算触发日全部是夏月1日）。

新增 `game_time.get_predict_date`：目标日期落在被跳过的月份时，取其后第一个季月的 1 日——这正是结算实际触发的时刻（成长判定按天数阈值，在时钟跳月后的首日成立）。九处「预计X日」调用一并改用该函数；加速天数计算、剂量公式、结算阈值均未改动。`get_sub_date` 本体不动：随机生日等既有功能依赖其现有行为。

验证（本地探针，未附）：修复前后对 4 个季月 × 5 个出生日 × 剩余天数 0–300 共 6020 组与逐小时时钟模拟真值比对，修复前 3744 组与真值不符、120 处非单调；修复后 0 组不符、0 处非单调。
