### PR TITLE
修复：（跨平台）场景路径切分统一使用系统路径分隔符

### DIFF
--- a/Script/StateMachine/default.py
+++ b/Script/StateMachine/default.py
@@ -1,3 +1,4 @@
+import os
 import random
 from types import FunctionType
 from Script.Config import game_config
@@ -252,7 +253,7 @@ def character_move_to_toilet(character_id: int):
         if not find_flag:
             # 遍历所有女厕所，寻找当前大场景内的厕所
             for place in constant.place_data["Toilet_Female"]:
-                if place.split("\\")[0] == now_position:
+                if place.split(os.sep)[0] == now_position:
                     to_toilet = map_handle.get_map_system_path_for_str(place)
                     find_flag = True
                     break
@@ -965,7 +966,7 @@ def character_move_to_rest_room(character_id: int):
     if find_flag == False:
         now_position = character_data.position[0]
         for place in constant.place_data["Rest_Room"]:
-            if place.split("\\")[0] == now_position:
+            if place.split(os.sep)[0] == now_position:
                 if map_handle.judge_scene_accessible(place,character_id) == "open":
                     to_rest_room = map_handle.get_map_system_path_for_str(place)
                     find_flag = True
@@ -992,7 +993,7 @@ def character_move_to_restaurant(character_id: int):
     now_position = character_data.position[0]
     find_flag = False
     for place in constant.place_data["Restaurant"]:
-        if place.split("\\")[0] == now_position:
+        if place.split(os.sep)[0] == now_position:
             to_rest_room = map_handle.get_map_system_path_for_str(place)
             find_flag = True
             break
@@ -1068,7 +1069,7 @@ def character_move_to_bathzone_locker_room(character_id: int):
     to_locker_room = []
     # 直接检索大浴场的更衣室
     for place in constant.place_data["Locker_Room"]:
-        if place.split("\\")[0] == "大浴场":
+        if place.split(os.sep)[0] == "大浴场":
             to_locker_room = map_handle.get_map_system_path_for_str(place)
             break
 
@@ -1088,7 +1089,7 @@ def character_move_to_bathzone_rest_room(character_id: int):
     to_rest_room = []
     # 直接检索大浴场的休息室
     for place in constant.place_data["Rest_Room"]:
-        if place.split("\\")[0] == "大浴场":
+        if place.split(os.sep)[0] == "大浴场":
             to_rest_room = map_handle.get_map_system_path_for_str(place)
             break
 
@@ -1108,7 +1109,7 @@ def character_move_to_training_locker_room(character_id: int):
     to_locker_room = []
     # 直接检索训练场的更衣室
     for place in constant.place_data["Locker_Room"]:
-        if place.split("\\")[0] == "训练":
+        if place.split(os.sep)[0] == "训练":
             to_locker_room = map_handle.get_map_system_path_for_str(place)
             break
 
@@ -1130,7 +1131,7 @@ def character_move_to_bath_room(character_id: int):
     now_position = character_data.position[0]
     find_flag = False
     for place in constant.place_data["Bathroom"]:
-        if place.split("\\")[0] == now_position:
+        if place.split(os.sep)[0] == now_position:
             to_bath_room = map_handle.get_map_system_path_for_str(place)
             find_flag = True
             break

--- a/Script/System/Dormitory_System/common.py
+++ b/Script/System/Dormitory_System/common.py
@@ -1,3 +1,4 @@
+import os
 import re
 from types import FunctionType
 from collections import defaultdict
@@ -213,7 +214,7 @@ def get_dormitory_occupants_text() -> str:
     for dormitory_place in Dormitory_all:
         count = 0
         tem_remove_id_set = set() # 用来保存需要删除id的临时set
-        dormitory_name = dormitory_place.split("\\")[-1]
+        dormitory_name = dormitory_place.split(os.sep)[-1]
         dormitory_son_text = f"    [{dormitory_name}]："
         # 遍历角色id
         dormitory_npc_name = ""
@@ -389,7 +390,7 @@ def new_character_get_dormitory(character_id: int):
                 continue
             # 遍历检查是否有同名客房，使用排序后的列表
             for room_full_path in guest_room_sorted:
-                if game_config.config_facility_open[room_id].name == room_full_path.split("\\")[-1]:
+                if game_config.config_facility_open[room_id].name == room_full_path.split(os.sep)[-1]:
                     final_room_list.append(room_full_path)
         
         # 查找第一个空闲的客房

--- a/Script/System/Dormitory_System/manage_dormitory_panel.py
+++ b/Script/System/Dormitory_System/manage_dormitory_panel.py
@@ -1,3 +1,4 @@
+import os
 import re
 from types import FunctionType
 from typing import Any, Dict, List, Optional, Tuple
@@ -902,5 +903,5 @@ class Manage_Dormitory_Panel:
         if dormitory_path == "":
             return _("暂无")
         if dormitory_path not in cache.scene_data:
-            return dormitory_path.split("\\")[-1]
+            return dormitory_path.split(os.sep)[-1]
         return cache.scene_data[dormitory_path].scene_name

--- a/Script/UI/Panel/confinement_and_training.py
+++ b/Script/UI/Panel/confinement_and_training.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Tuple
 from types import FunctionType
 from Script.Core import cache_control, game_type, get_text, flow_handle, constant
@@ -500,7 +501,7 @@ class Confinement_And_Training_Manage_Panel:
                 now_text += _("目前的囚犯有：")
                 for chara_id in cache.rhodes_island.current_prisoners:
                     tem_character_data: game_type.Character = cache.character_data[chara_id]
-                    live_room = tem_character_data.dormitory.split("\\")[-1]
+                    live_room = tem_character_data.dormitory.split(os.sep)[-1]
                     now_text += _(" [{0}]{1} - {2}  ").format(str(tem_character_data.adv).rjust(4,'0'), tem_character_data.name, live_room)
                 now_text += f"\n"
 

--- a/Script/UI/Panel/invite_visitor_panel.py
+++ b/Script/UI/Panel/invite_visitor_panel.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from types import FunctionType
 from Script.Core import cache_control, game_type, get_text, flow_handle, constant
@@ -53,7 +54,7 @@ def sort_guest_room_key(room_path):
     return: int -- 提取的客房编号，如果无法解析则返回999
     """
     # 提取客房编号，例如从 "访客\\客房10" 中提取 10
-    room_name = room_path.split("\\")[-1]
+    room_name = room_path.split(os.sep)[-1]
     if "客房" in room_name:
         try:
             room_number = int(room_name.replace("客房", ""))
@@ -290,7 +291,7 @@ class Invite_Visitor_Panel:
                 now_text += _(" 目前的访客有：")
                 for chara_id in cache.rhodes_island.visitor_info:
                     character_data: game_type.Character = cache.character_data[chara_id]
-                    live_room = character_data.dormitory.split("\\")[-1]
+                    live_room = character_data.dormitory.split(os.sep)[-1]
                     leav_time = game_time.get_date_until_day(cache.rhodes_island.visitor_info[chara_id])
                     now_text += _(" [{0}]{1}，居住房间：{2}，离开{3}\n").format(str(character_data.adv).rjust(4,'0'), character_data.name, live_room, leav_time)
                 now_text += f"\n"

--- a/Script/UI/Panel/see_character_info_panel.py
+++ b/Script/UI/Panel/see_character_info_panel.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from types import FunctionType
 from Script.UI.Moudle import draw, panel
@@ -1044,7 +1045,7 @@ class CharacterDailyText:
             text_list += _(" 今日上午：工作    今日下午：工作    今日晚上：{0}").format(entertainment_text_list[2])
         else:
             text_list += _(" 今日上午：{0}    今日下午：{1}    今日晚上：{2}").format(entertainment_text_list[0], entertainment_text_list[1], entertainment_text_list[2])
-        live_room = character_data.dormitory.split("\\")[-1]
+        live_room = character_data.dormitory.split(os.sep)[-1]
         text_list += _("\n居住房间：{0}").format(live_room)
 
         text_draw = draw.LeftDraw()
@@ -1109,7 +1110,7 @@ class CharacterVisitorText:
             stay_text = attitude_data.name
             break
         leav_time = game_time.get_date_until_day(cache.rhodes_island.visitor_info[character_id])
-        live_room = character_data.dormitory.split("\\")[-1]
+        live_room = character_data.dormitory.split(os.sep)[-1]
         text_list += _("留下意愿：{0}     ").format(stay_text)
         text_list += _("离开时间：{0}     ").format(leav_time)
         text_list += _("居住房间：{0}").format(live_room)


### PR DESCRIPTION
`Script/StateMachine/default.py` 七处移动类状态机用 `place.split("\\")[0]` 匹配场景路径首段，而 `place_data` 里的路径由 `os.sep.join` 生成、解码函数 `get_map_system_path_for_str` 也用 `os.sep` 切分。Windows 上 `os.sep` 就是 `"\\"`，行为逐字不变；非 Windows 平台上路径是 `/` 分隔，这七处永不匹配——其中「去大浴场更衣室/休息室」「去训练区更衣室」三处没有随机兜底，函数不设行为直接返回，晚间洗澡需求触发后角色陷入无限空转、洗澡标记跨日不清，逐渐蔓延为全基地 NPC 冻结（其余四处有随机兜底，只会选错区块）。

另有八处同类写法用 `split("\\")[-1]` 取路径末段作为房间名（干员信息、监禁调教、邀请访客三个面板与宿舍系统）：七处在非 Windows 平台会把房间名显示成整条路径；`Dormitory_System/common.py` 中一处拿末段与设施名做相等比较来筛选访客客房，非 Windows 上恒不匹配、可用客房列表恒为空。

现将这十五处统一改为 `split(os.sep)`，与既有解码函数一致；Windows 上行为逐字不变。

虽然游戏本身只支持 windows，但是代码对 linux 的兼容性可以让 linux 服务器上跑无头开发的情况容易很多
