### PR TITLE
清理：（行为循环）移除时长归零分支中恒不可达的等待判断

### DIFF
--- a/Script/Design/character_behavior.py
+++ b/Script/Design/character_behavior.py
@@ -308,9 +308,6 @@ def judge_character_status_time_over(character_id: int, now_time: datetime.datet
         character_data.behavior = game_type.Behavior()
         character_data.behavior.start_time = now_time
         character_data.behavior.duration = 1
-        # 等待状态下则不转为空闲状态，直接跳出
-        if character_data.behavior.behavior_id == constant.Behavior.WAIT:
-            return 1
         character_data.state = constant.CharacterStatus.STATUS_ARDER
         # print(f"debug {character_data.name}的add_time = 0，已重置为当前时间：start_time = {character_data.behavior.start_time}")
         return 0


### PR DESCRIPTION
### 问题

`judge_character_status_time_over()` 的 `add_time <= 0` 分支中有一段恒不可达的判断：

```python
character_data.behavior = game_type.Behavior()
character_data.behavior.start_time = now_time
character_data.behavior.duration = 1
# 等待状态下则不转为空闲状态，直接跳出
if character_data.behavior.behavior_id == constant.Behavior.WAIT:
    return 1
```

上方刚把 `character_data.behavior` 整体重建为 `game_type.Behavior()`，其默认 `behavior_id` 恒为 `share_blankly`，因此紧随其后的 `WAIT` 判断静态恒为假，`return 1` 永远不会执行。

### 来历

该判断在 2024-11（1bf3aa0ee）引入时检查的是重建前的 `character_data.state == STATUS_WAIT`（state 不被 `Behavior()` 重建，判断有效）；2025-05 状态机字段统一重构（e671c9d68）把它机械替换为重建后的 `behavior.behavior_id`，语义自此失效。

没有选择「恢复原判断」或「把判断挪到重建之前」：已核查当前所有写入 `WAIT` 的位置都带正时长，正常游玩不会以 `WAIT + 非正时长` 进入该分支，原特例已无对应场景；而把判断挪到重建前会让角色带着 0 时长的 `WAIT` 永久跳出，反而引入新问题。

### 修复

直接删除这 3 行死代码，不改变任何可达行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
