### PR TITLE
修复：（群交）力竭退出只剩1人转为单人H时未关闭群交模式

### DIFF
--- a/data/csv/Behavior_Effect.csv
+++ b/data/csv/Behavior_Effect.csv
@@ -173,7 +173,7 @@ int,str,str
 372,ask_group_sex_fail,530
 373,group_sex_pl_hp_0_end,529 - 407 - 636 - 800 - 10011
 374,group_sex_npc_hp_0_end,1503 - 528 - 403 - 635
-375,group_sex_to_h,9999
+375,group_sex_to_h,10011
 376,join_group_sex,CVE_A1_E|56_G_1 - 462 - 602 - 604 - 1408 - 1418 - 10010
 377,refuse_join_group_sex,23 - 24 - 153 - 364 - 1512 - 1524 - 1602 - 1721
 378,other_sex_be_found_to_group_sex,405 - 462 - 464 - 473 - 476 - 603 - 605 - 753 - 1404 - 1409 - 10010


### PR DESCRIPTION
群交中干员逐个力竭退出、只剩 1 人时会转为一对一 H，但群交模式开关没有一起关掉。之后游戏仍把这场 H 当作群交：结束类指令消失、群交专用指令残留，这段 H 被误记为群交初体验，群交成就场次不再重置，「结束H」还会被群交结算多演一次。

本 PR 在转换行为 `group_sex_to_h` 的效果链里补上「关闭群交模式」，转换后按普通一对一 H 对待，H 本身照常继续。

连带变化：转换后最后一人再力竭时，改走普通 H 的力竭结束流程（原先走群交结束流程）。

已做修复前后对照验证：上述问题全部消失；多人群交继续、手动结束群交等场景行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
