### PR TITLE
修复：（多周目）角色属性表与模板共享引用，导致新周目继承越界

### DIFF
--- a/Script/Design/character_handle.py
+++ b/Script/Design/character_handle.py
@@ -1,3 +1,4 @@
+import copy
 import random
 from types import FunctionType
 from Script.Core import (
@@ -68,9 +69,9 @@ def init_character(character_id: int, character_tem: game_type.NpcTem, collect_r
     now_character.target_character_id = character_id
     now_character.favorability = {0:0}
     now_character.trust = 0
-    now_character.ability = character_tem.Ability
-    now_character.experience = character_tem.Experience
-    now_character.talent = character_tem.Talent
+    now_character.ability = copy.deepcopy(character_tem.Ability)
+    now_character.experience = copy.deepcopy(character_tem.Experience)
+    now_character.talent = copy.deepcopy(character_tem.Talent)
     now_character.hit_point_max = character_tem.Hp
     now_character.mana_point_max = character_tem.Mp
     now_character.dormitory = character_tem.Dormitory


### PR DESCRIPTION
创建角色时，能力/经验/素质三张表是直接引用模板的同一份字典，周目内角色的成长会一并写进模板。到开新周目时「按模板重建」因此失效：没有陷落的干员也保留了上一周目的能力和经验，素质则所有人都不重置，超出了「继承仅限陷落干员」的设计范围。

本 PR 在创建角色时改为复制这三张表，切断共享。

连带变化：修复后新周目将真正按设计重置（未陷落干员的能力/经验、全员的素质回到基线，子代按出生模板重建）；旧存档里已经固化的数据不做回溯修改。

已验证：全部干员创建后与模板不再共享、修改角色不再影响模板；数据构建与游戏启动正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
