### PR TITLE
修复：（访客）今日离岛提醒把次日离开的访客也提前算入

### DIFF
--- a/Script/UI/Panel/invite_visitor_panel.py
+++ b/Script/UI/Panel/invite_visitor_panel.py
@@ -246,7 +246,7 @@ def get_today_departing_visitors():
     for visitor_id in now_visitor_id_list:
         # 判断时间为明天0点
         judge_time = game_time.get_sub_date(day=1)
-        judge_time.replace(hour=0, minute=0, second=0, microsecond=0)
+        judge_time = judge_time.replace(hour=0, minute=0, second=0, microsecond=0)
         # 判定今天结束后是否要离开
         if game_time.judge_date_big_or_small(judge_time, cache.rhodes_island.visitor_info[visitor_id]):
             # 计算访客留下概率


### PR DESCRIPTION
总务处的今日待办里，「今日有访客要离开」的提醒会把次日白天才离开的访客也提前一天算进来。原因是判定时刻的午夜取整没有生效：`datetime.replace` 返回新对象，返回值未被接收，判定用的实际是「明天的当前时刻」而非注释所写的「明天0点」。接收返回值即可，提醒按自然日生效。