### PR TITLE
修复：（宿舍）进入特殊住宿时统一登记规则，不再把特殊房间写入登记宿舍

### DIFF
--- a/Script/System/Dormitory_System/common.py
+++ b/Script/System/Dormitory_System/common.py
@@ -223,6 +223,18 @@ def get_residence_type(character_id: int) -> str:
     return "dormitory"
 
 
+def register_permanent_dormitory(character_id: int) -> None:
+    """
+    进入特殊住宿前登记原宿舍
+    输入类型: character_id(int)
+    输出类型: 无
+    功能: 角色即将迁入特殊房间时调用；当前住在开放普通宿舍时把该宿舍记为登记宿舍，否则不改动（避免把特殊房间写入登记字段）
+    """
+    character_data: game_type.Character = cache.character_data[character_id]
+    if character_data.dormitory in get_open_dormitory_room_occupancy():
+        character_data.permanent_dormitory = character_data.dormitory
+
+
 def restore_character_dormitory(character_id: int) -> str:
     """
     结束临时住宿状态时恢复角色的宿舍归属

--- a/Script/System/Dormitory_System/manage_dormitory_panel.py
+++ b/Script/System/Dormitory_System/manage_dormitory_panel.py
@@ -850,8 +850,7 @@ class Manage_Dormitory_Panel:
             return
 
         character_data = cache.character_data[character_id]
-        if not self._is_manager_room_path(character_data.dormitory) and character_data.permanent_dormitory == "":
-            character_data.permanent_dormitory = character_data.dormitory
+        common.register_permanent_dormitory(character_id)
         character_data.dormitory = manager_room_path
 
         character_position = character_data.position

--- a/Script/UI/Panel/assistant_panel.py
+++ b/Script/UI/Panel/assistant_panel.py
@@ -355,7 +355,8 @@ class Assistant_Panel:
             # 此处不可以用翻译地点
             if service_cid == 7:
                 if target_data.assistant_services[service_cid] == 1:
-                    target_data.permanent_dormitory = target_data.dormitory
+                    from Script.System.Dormitory_System import common as dormitory_common
+                    dormitory_common.register_permanent_dormitory(character_data.assistant_character_id)
                     target_data.dormitory = map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"])
                 elif target_data.dormitory == map_handle.get_map_system_path_str_for_list(["中枢", "博士房间"]):
                     from Script.System.Dormitory_System import common as dormitory_common

--- a/Script/UI/Panel/confinement_and_training.py
+++ b/Script/UI/Panel/confinement_and_training.py
@@ -200,8 +200,8 @@ def chara_become_prisoner(character_id: int):
     # 服装结算
     clothing.handle_prisoner_clothing(character_id)
     # 当前位置作为宿舍，并保存旧宿舍
-    if character_data.permanent_dormitory == "":
-        character_data.permanent_dormitory = character_data.dormitory
+    from Script.System.Dormitory_System import common as dormitory_common
+    dormitory_common.register_permanent_dormitory(character_id)
     character_data.dormitory = map_handle.get_map_system_path_str_for_list(character_data.position)
     # 给予屈服2，恐怖1，反发3，但如果有隶属系陷落，则可以减轻该效果
     target_fall = attr_calculation.get_character_fall_level(character_id, minus_flag=True)

--- a/Script/UI/Panel/manage_basement_panel.py
+++ b/Script/UI/Panel/manage_basement_panel.py
@@ -1355,7 +1355,7 @@ class Change_Npc_Work_Panel:
             # 更新监狱长id
             cache.rhodes_island.current_warden_id = character_id
             # 更新监狱长的宿舍
-            target_data.permanent_dormitory = target_data.dormitory
+            common.register_permanent_dormitory(character_id)
             target_data.dormitory = map_handle.get_map_system_path_str_for_list(["关押", "休息室"])
         # 更新罗德岛的工作人员及状态
         basement.update_work_people()


### PR DESCRIPTION
角色进入特殊住宿（开启助理同居、任命宿舍管理员、任命监狱长、监禁）时会把原宿舍记为登记宿舍，供退出时回迁。四处入口的写法各不相同：同居和监狱长两处无条件覆盖，监禁和舍管两处只在登记宿舍为空时写入。角色已经住在特殊房间时再叠加另一种特殊住宿（例如已任宿舍管理员再开启同居），无条件写法会把舍管房写进登记宿舍。之后退出时登记宿舍不是普通宿舍，角色被当作新入住者分到别的房间，回不到原来的宿舍。

本 PR 把四处入口统一为一个共享函数：只在角色当前住在开放的普通宿舍时才登记，否则登记宿舍保持不动。此后登记宿舍只可能是普通宿舍或空，与 #300 定义的语义一致。

连带变化：舍管任命处原有的「不是舍管房且登记为空才写」判断被新规则覆盖，一并去掉。角色从普通宿舍直接进入任一特殊住宿时行为不变。

已做修复前后对照验证：同一存档中对同一干员执行「任命舍管→开启同居→关闭同居→撤销舍管」和「任命舍管→任命监狱长→撤销监狱长→撤销舍管」，修复前登记宿舍在第二步被写成舍管房、退出后被分到别的房间；修复后登记宿舍保持为原宿舍、退出后回到原宿舍。四处入口不叠加时的结果修复前后一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
