### PR TITLE
邀请H失败结算改为显式传入目标角色，不再临时切换玩家交互对象

### DIFF
--- a/Script/Design/character_handle.py
+++ b/Script/Design/character_handle.py
@@ -361,7 +361,7 @@ def add_favorability(
     增加目标角色对当前角色的好感
     Keyword arguments:
     character_id -- 当前角色id
-    target_id -- 目标角色id
+    target_id -- 目标角色id，写入方向以此参数为准
     now_add_favorability -- 增加的好感
     target_change -- 角色状态改变对象
     """
@@ -394,7 +394,7 @@ def add_favorability(
     # else:
 
     # NPC对玩家
-    if (character_id != 0) and (character_data.target_character_id == 0):
+    if (character_id != 0) and (target_id == 0):
         character_data.favorability[target_id] += now_add_favorability
         character_data.favorability[target_id] = min(100000, character_data.favorability[target_id])
         # print(f"debug change_data = {change_data}")
@@ -402,7 +402,7 @@ def add_favorability(
             change_data.favorability += now_add_favorability
 
     # 对NPC
-    if character_data.target_character_id != 0:
+    if target_id != 0:
         target_data.favorability[character_id] += now_add_favorability
         target_data.favorability[character_id] = min(100000, target_data.favorability[character_id])
         if target_change is not None:
@@ -412,7 +412,7 @@ def add_favorability(
     #     add_favorability(target_id, character_id, old_add_favorability, None, None, now_time)
 
     # 记录好感度增加
-    if character_id == 0 or character_data.target_character_id == 0:
+    if character_id == 0 or target_id == 0:
         cache.rhodes_island.total_favorability_increased += now_add_favorability
 
 

--- a/Script/Settle/default.py
+++ b/Script/Settle/default.py
@@ -7033,7 +7033,6 @@ def handle_group_sex_fail_add_just(
     if not add_time:
         return
     character_data: game_type.Character = cache.character_data[character_id]
-    original_target_character_id = character_data.target_character_id
     scene_path_str = map_handle.get_map_system_path_str_for_list(character_data.position)
     scene_data: game_type.Scene = cache.scene_data[scene_path_str]
     # 遍历场景内所有角色
@@ -7045,9 +7044,7 @@ def handle_group_sex_fail_add_just(
             continue
         # 如果是拒绝者，则进行邀请H失败结算
         if handle_premise.handle_group_sex_fail_and_self_refuse(chara_id):
-            character_data.target_character_id = chara_id
-            handle_do_h_failed_adjust(0, add_time, change_data, now_time)
-    character_data.target_character_id = original_target_character_id
+            settle_do_h_failed_adjust(0, chara_id, add_time, change_data)
 
 
 @settle_behavior.add_settle_behavior_effect(constant_effect.BehaviorEffect.BOARD_GAME_WIN_ADD_ADJUST)
@@ -9283,11 +9280,27 @@ def handle_do_h_failed_adjust(
     if not add_time:
         return
     character_data: game_type.Character = cache.character_data[character_id]
-    if character_data.target_character_id:
-        target_data: game_type.Character = cache.character_data[character_data.target_character_id]
+    settle_do_h_failed_adjust(character_id, character_data.target_character_id, add_time, change_data)
+
+
+def settle_do_h_failed_adjust(character_id: int, target_character_id: int, add_time: int, change_data: game_type.CharacterStatusChange) -> None:
+    """
+    对指定交互对象结算邀请H失败的反感、愤怒、好感与信赖变化。
+    参数:
+        character_id (int): 发起邀请的角色id。
+        target_character_id (int): 拒绝邀请的角色id，0时不结算。
+        add_time (int): 结算时长，0时不结算。
+        change_data (CharacterStatusChange): 发起者的变化记录，目标变化记入对应target_change。
+    返回:
+        None: 直接更新角色数值与变化记录，不修改交互对象。
+    """
+    if not add_time:
+        return
+    if target_character_id:
+        target_data: game_type.Character = cache.character_data[target_character_id]
 
         # 高陷落不进行该判断
-        chara_fall = attr_calculation.get_character_fall_level(character_data.target_character_id)
+        chara_fall = attr_calculation.get_character_fall_level(target_character_id)
         if chara_fall >= 4:
             return
 
@@ -9311,7 +9324,7 @@ def handle_do_h_failed_adjust(
         target_data.angry_point += 100
         target_data.sp_flag.angry_with_player = True
         # 降好感
-        base_chara_favorability_and_trust_common_settle(character_id, add_time, True, 0, -15, change_data)
+        base_chara_favorability_and_trust_common_settle(character_id, add_time, True, 0, -15, change_data, target_character_id=target_character_id)
         # 降信赖
         now_lust_multiple = target_data.trust * 0.4 + 5
         if now_lust_multiple < 0:


### PR DESCRIPTION
群交邀请失败后，会对场上每个拒绝者逐一结算处罚。现有实现是把玩家的交互对象临时切换成拒绝者、结算完再改回来，借此复用单人的邀请H失败结算；`add_favorability` 内部也依赖读取当前交互对象来判断好感写给谁。

本次把邀请H失败结算提取为显式接收目标角色id的函数，逐个拒绝者结算时直接传入对应id，不再改动玩家的交互对象；`add_favorability` 改为直接按已有的 `target_id` 参数决定好感写入方向。原效果入口保留，单人场景仍按当前交互对象结算。
