### PR TITLE
修复：辅助操作结束后恢复临时切换的交互对象

### DIFF
--- a/Script/Design/handle_npc_ai_in_h.py
+++ b/Script/Design/handle_npc_ai_in_h.py
@@ -751,8 +751,12 @@ def npc_ai_in_group_sex_type_3():
             # print(f"debug {character_data.name}加入侍奉{game_config.config_status[ A_template_data[1][1]].name}")
         else:
             # 获取该部位的状态id列表
-            pl_character_data.target_character_id = character_id
-            new_status_id_list = group_sex_panel.get_status_id_list_from_group_sex_body_part(body_part)
+            old_target_character_id = pl_character_data.target_character_id
+            try:
+                pl_character_data.target_character_id = character_id
+                new_status_id_list = group_sex_panel.get_status_id_list_from_group_sex_body_part(body_part)
+            finally:
+                pl_character_data.target_character_id = old_target_character_id
             # 随机选择一个状态
             status_id = random.choice(new_status_id_list)
             # 如果是侍奉

--- a/Script/Settle/item_effect.py
+++ b/Script/Settle/item_effect.py
@@ -574,27 +574,31 @@ def handle_adjust_body_manage_day_item(
         return
     character_data: game_type.Character = cache.character_data[character_id]
     # 这里把交互对象设为自己是因为下面的装备/取下道具函数都是让交互对象结算的
-    character_data.target_character_id = character_id
-    # 身体管理_乳头夹
-    if handle_premise.handle_ask_equp_nipple_clamp_in_day(character_id) and not handle_premise.handle_self_now_nipple_clamp(character_id):
-        handle_target_nipple_clamp_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_nipple_clamp_in_day(character_id) and handle_premise.handle_self_now_nipple_clamp(character_id):
-        handle_target_nipple_clamp_off(character_id, add_time, change_data, now_time)
-    # 身体管理_阴蒂夹
-    if handle_premise.handle_ask_equp_clit_clamp_in_day(character_id) and not handle_premise.handle_self_now_clit_clamp(character_id):
-        handle_target_clit_clamp_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_clit_clamp_in_day(character_id) and handle_premise.handle_self_now_clit_clamp(character_id):
-        handle_target_clit_clamp_off(character_id, add_time, change_data, now_time)
-    # 身体管理_V振动棒
-    if handle_premise.handle_ask_equp_v_bibrator_in_day(character_id) and not handle_premise.handle_self_now_vibrator_insertion(character_id):
-        handle_target_vibrator_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_v_bibrator_in_day(character_id) and handle_premise.handle_self_now_vibrator_insertion(character_id):
-        handle_target_vibrator_off(character_id, add_time, change_data, now_time)
-    # 身体管理_A振动棒
-    if handle_premise.handle_ask_equp_a_bibrator_in_day(character_id) and not handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
-        handle_target_anal_vibrator_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_a_bibrator_in_day(character_id) and handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
-        handle_target_anal_vibrator_off(character_id, add_time, change_data, now_time)
+    old_target_character_id = character_data.target_character_id
+    try:
+        character_data.target_character_id = character_id
+        # 身体管理_乳头夹
+        if handle_premise.handle_ask_equp_nipple_clamp_in_day(character_id) and not handle_premise.handle_self_now_nipple_clamp(character_id):
+            handle_target_nipple_clamp_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_nipple_clamp_in_day(character_id) and handle_premise.handle_self_now_nipple_clamp(character_id):
+            handle_target_nipple_clamp_off(character_id, add_time, change_data, now_time)
+        # 身体管理_阴蒂夹
+        if handle_premise.handle_ask_equp_clit_clamp_in_day(character_id) and not handle_premise.handle_self_now_clit_clamp(character_id):
+            handle_target_clit_clamp_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_clit_clamp_in_day(character_id) and handle_premise.handle_self_now_clit_clamp(character_id):
+            handle_target_clit_clamp_off(character_id, add_time, change_data, now_time)
+        # 身体管理_V振动棒
+        if handle_premise.handle_ask_equp_v_bibrator_in_day(character_id) and not handle_premise.handle_self_now_vibrator_insertion(character_id):
+            handle_target_vibrator_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_v_bibrator_in_day(character_id) and handle_premise.handle_self_now_vibrator_insertion(character_id):
+            handle_target_vibrator_off(character_id, add_time, change_data, now_time)
+        # 身体管理_A振动棒
+        if handle_premise.handle_ask_equp_a_bibrator_in_day(character_id) and not handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
+            handle_target_anal_vibrator_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_a_bibrator_in_day(character_id) and handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
+            handle_target_anal_vibrator_off(character_id, add_time, change_data, now_time)
+    finally:
+        character_data.target_character_id = old_target_character_id
 
 
 @settle_behavior.add_settle_behavior_effect(constant_effect.BehaviorEffect.ADJUST_BODY_MANAGE_SLEEP_ITEM)
@@ -618,27 +622,31 @@ def handle_adjust_body_manage_sleep_item(
         return
     character_data: game_type.Character = cache.character_data[character_id]
     # 这里把交互对象设为自己是因为下面的装备/取下道具函数都是让交互对象结算的
-    character_data.target_character_id = character_id
-    # 身体管理_乳头夹
-    if handle_premise.handle_ask_equp_nipple_clamp_in_sleep(character_id) and not handle_premise.handle_self_now_nipple_clamp(character_id):
-        handle_target_nipple_clamp_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_nipple_clamp_in_sleep(character_id) and handle_premise.handle_self_now_nipple_clamp(character_id):
-        handle_target_nipple_clamp_off(character_id, add_time, change_data, now_time)
-    # 身体管理_阴蒂夹
-    if handle_premise.handle_ask_equp_clit_clamp_in_sleep(character_id) and not handle_premise.handle_self_now_clit_clamp(character_id):
-        handle_target_clit_clamp_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_clit_clamp_in_sleep(character_id) and handle_premise.handle_self_now_clit_clamp(character_id):
-        handle_target_clit_clamp_off(character_id, add_time, change_data, now_time)
-    # 身体管理_V振动棒
-    if handle_premise.handle_ask_equp_v_bibrator_in_sleep(character_id) and not handle_premise.handle_self_now_vibrator_insertion(character_id):
-        handle_target_vibrator_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_v_bibrator_in_sleep(character_id) and handle_premise.handle_self_now_vibrator_insertion(character_id):
-        handle_target_vibrator_off(character_id, add_time, change_data, now_time)
-    # 身体管理_A振动棒
-    if handle_premise.handle_ask_equp_a_bibrator_in_sleep(character_id) and not handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
-        handle_target_anal_vibrator_on(character_id, add_time, change_data, now_time)
-    elif not handle_premise.handle_ask_equp_a_bibrator_in_sleep(character_id) and handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
-        handle_target_anal_vibrator_off(character_id, add_time, change_data, now_time)
+    old_target_character_id = character_data.target_character_id
+    try:
+        character_data.target_character_id = character_id
+        # 身体管理_乳头夹
+        if handle_premise.handle_ask_equp_nipple_clamp_in_sleep(character_id) and not handle_premise.handle_self_now_nipple_clamp(character_id):
+            handle_target_nipple_clamp_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_nipple_clamp_in_sleep(character_id) and handle_premise.handle_self_now_nipple_clamp(character_id):
+            handle_target_nipple_clamp_off(character_id, add_time, change_data, now_time)
+        # 身体管理_阴蒂夹
+        if handle_premise.handle_ask_equp_clit_clamp_in_sleep(character_id) and not handle_premise.handle_self_now_clit_clamp(character_id):
+            handle_target_clit_clamp_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_clit_clamp_in_sleep(character_id) and handle_premise.handle_self_now_clit_clamp(character_id):
+            handle_target_clit_clamp_off(character_id, add_time, change_data, now_time)
+        # 身体管理_V振动棒
+        if handle_premise.handle_ask_equp_v_bibrator_in_sleep(character_id) and not handle_premise.handle_self_now_vibrator_insertion(character_id):
+            handle_target_vibrator_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_v_bibrator_in_sleep(character_id) and handle_premise.handle_self_now_vibrator_insertion(character_id):
+            handle_target_vibrator_off(character_id, add_time, change_data, now_time)
+        # 身体管理_A振动棒
+        if handle_premise.handle_ask_equp_a_bibrator_in_sleep(character_id) and not handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
+            handle_target_anal_vibrator_on(character_id, add_time, change_data, now_time)
+        elif not handle_premise.handle_ask_equp_a_bibrator_in_sleep(character_id) and handle_premise.handle_self_now_vibrator_insertion_anal(character_id):
+            handle_target_anal_vibrator_off(character_id, add_time, change_data, now_time)
+    finally:
+        character_data.target_character_id = old_target_character_id
 
 
 @settle_behavior.add_settle_behavior_effect(constant_effect.BehaviorEffect.USE_BODY_LUBRICANT)

--- a/Script/System/Sex_System/group_sex_panel.py
+++ b/Script/System/Sex_System/group_sex_panel.py
@@ -646,17 +646,21 @@ class Edit_Group_Sex_Temple_Panel:
     def show_status_list(self, temple_id: str, body_part: str):
         """绘制可选择的状态列表"""
         # 如果当前已指定对象角色id，则将其设为玩家的交互对象
-        if body_part != _("侍奉"):
-            target_chara_id = self.pl_character_data.h_state.group_sex_body_template_dict[temple_id][0][body_part][0]
-            if target_chara_id != -1:
-                self.pl_character_data.target_character_id = target_chara_id
-        else:
-            target_chara_id_list = self.pl_character_data.h_state.group_sex_body_template_dict[temple_id][1][0]
-            # 侍奉中则将最后一位设为玩家的交互对象
-            if -1 not in target_chara_id_list:
-                target_chara_id = target_chara_id_list[-1]
-                self.pl_character_data.target_character_id = target_chara_id
-        new_status_id_list = get_status_id_list_from_group_sex_body_part(body_part)
+        old_target_character_id = self.pl_character_data.target_character_id
+        try:
+            if body_part != _("侍奉"):
+                target_chara_id = self.pl_character_data.h_state.group_sex_body_template_dict[temple_id][0][body_part][0]
+                if target_chara_id != -1:
+                    self.pl_character_data.target_character_id = target_chara_id
+            else:
+                target_chara_id_list = self.pl_character_data.h_state.group_sex_body_template_dict[temple_id][1][0]
+                # 侍奉中则将最后一位设为玩家的交互对象
+                if -1 not in target_chara_id_list:
+                    target_chara_id = target_chara_id_list[-1]
+                    self.pl_character_data.target_character_id = target_chara_id
+            new_status_id_list = get_status_id_list_from_group_sex_body_part(body_part)
+        finally:
+            self.pl_character_data.target_character_id = old_target_character_id
         while 1:
             line = draw.LineDraw("-", self.width)
             line.draw()

--- a/Script/UI/Panel/debug_panel.py
+++ b/Script/UI/Panel/debug_panel.py
@@ -405,35 +405,39 @@ class TALK_QUICK_TEST:
                 draw_text += _("  交互对象：未填写，本测试中默认选择为博士\n")
                 end_chara_id = 0
         # 设置交互对象
-        cache.character_data[start_chara_id].target_character_id = end_chara_id
+        old_target_character_id = cache.character_data[start_chara_id].target_character_id
+        try:
+            cache.character_data[start_chara_id].target_character_id = end_chara_id
 
-        # 输出口上文本
-        talk_context = game_config.config_talk[full_talk_id].context
-        draw_text += _("\n口上原文本：\n  {0}\n").format(talk_context)
-        draw_text += _("口上输出文本：\n  {0}\n").format(talk.code_text_to_draw_text(talk_context, start_chara_id))
-        # 遍历前提条件
-        draw_text += _("\n前提条件：\n")
-        for premise in game_config.config_talk_premise_data[full_talk_id]:
-            # 综合数值前提判定
-            if "CVP" in premise:
-                premise_all_value_list = premise.split("_")[1:]
-                now_add_weight = handle_premise.handle_comprehensive_value_premise(start_chara_id, premise_all_value_list)
-            # 其他正常口上判定
+            # 输出口上文本
+            talk_context = game_config.config_talk[full_talk_id].context
+            draw_text += _("\n口上原文本：\n  {0}\n").format(talk_context)
+            draw_text += _("口上输出文本：\n  {0}\n").format(talk.code_text_to_draw_text(talk_context, start_chara_id))
+            # 遍历前提条件
+            draw_text += _("\n前提条件：\n")
+            for premise in game_config.config_talk_premise_data[full_talk_id]:
+                # 综合数值前提判定
+                if "CVP" in premise:
+                    premise_all_value_list = premise.split("_")[1:]
+                    now_add_weight = handle_premise.handle_comprehensive_value_premise(start_chara_id, premise_all_value_list)
+                # 其他正常口上判定
+                else:
+                    now_add_weight = constant.handle_premise_data[premise](start_chara_id)
+                if now_add_weight:
+                    draw_text += _("  {0}：满足(√)\n").format(premise)
+                else:
+                    draw_text += _("  {0}：不满足(X)\n").format(premise)
+                    pass_flag = False
+
+            # 输出测试结果
+            if pass_flag:
+                draw_text += _("\n最终结果：\n  测试通过，该口上可以触发\n")
             else:
-                now_add_weight = constant.handle_premise_data[premise](start_chara_id)
-            if now_add_weight:
-                draw_text += _("  {0}：满足(√)\n").format(premise)
-            else:
-                draw_text += _("  {0}：不满足(X)\n").format(premise)
-                pass_flag = False
+                draw_text += _("\n最终结果：\n  测试未通过，该口上无法触发\n")
 
-        # 输出测试结果
-        if pass_flag:
-            draw_text += _("\n最终结果：\n  测试通过，该口上可以触发\n")
-        else:
-            draw_text += _("\n最终结果：\n  测试未通过，该口上无法触发\n")
-
-        return draw_text, pass_flag
+            return draw_text, pass_flag
+        finally:
+            cache.character_data[start_chara_id].target_character_id = old_target_character_id
 
 
     def run_batch_talk_test_in_groups(self, target_chara_id: int, talk_id_list: List[int]):


### PR DESCRIPTION
有几处代码会临时把角色的交互对象（target_character_id）改成别的值，以便复用按交互对象结算或查询的函数，包括身体管理的白天/睡眠道具穿脱结算、群交模板面板的动作列表查询、群交抢占AI和口上快速测试，此前用完后交互对象会停留在临时值上。本次统一改为先保存原交互对象，在 try/finally 中完成查询或结算后恢复，与普通群交AI中已有的写法一致。除新增的保存/恢复语句外，其余改动均为缩进调整。
