### PR TITLE
feature:部位性知识与心理处女的初步开发

### DIFF
--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -1772,6 +1772,8 @@ class Character:
         """ 角色能力 """
         self.experience: Dict[int, int] = {}
         """ 角色经验 """
+        self.mental_virginity: Dict[int, int] = {}
+        """ 各快感部位的心理处女认知状态，键为快感状态id，值见Sex_System.mental_virginity；空字典表示尚无需要固化的认知记录 """
         self.juel: Dict[int, int] = {}
         """ 角色宝珠 """
         self.profession: int = 0

--- a/Script/Design/handle_npc_ai_in_h.py
+++ b/Script/Design/handle_npc_ai_in_h.py
@@ -438,11 +438,24 @@ def settle_unconscious_semen_and_cloth(character_id: int) -> None:
         当角色在恢复意识时触发的二段行为。
     """
     from Script.Design import second_behavior
+    from Script.System.Sex_System import mental_virginity
     # 从缓存中获取角色数据
     character_data: game_type.Character = cache.character_data[character_id]
     # 对数据进行去重
     character_data.dirty.body_semen_in_unconscious = list(set(character_data.dirty.body_semen_in_unconscious))
     character_data.dirty.cloth_semen_in_unconscious = list(set(character_data.dirty.cloth_semen_in_unconscious))
+    # 在污浊标记被清除前固化角色从身体、衣物和失窃服装中得到的认知，避免换装或清洗后心理状态倒退。
+    discovery_cloth_part_list = character_data.dirty.cloth_semen_in_unconscious.copy()
+    if character_data.cloth.stolen_panties_in_unconscious:
+        discovery_cloth_part_list.append(9)
+    if character_data.cloth.stolen_socks_in_unconscious:
+        discovery_cloth_part_list.append(10)
+    if character_data.dirty.body_semen_in_unconscious or discovery_cloth_part_list:
+        mental_virginity.record_unconscious_discovery(
+            character_id,
+            character_data.dirty.body_semen_in_unconscious,
+            discovery_cloth_part_list,
+        )
     # 触发角色的部位精液二段行为
     for body_part in character_data.dirty.body_semen_in_unconscious:
         second_behavior_id = "in_unconscious_cum_on_body_" + str(body_part)

--- a/Script/Settle/common_default.py
+++ b/Script/Settle/common_default.py
@@ -997,3 +997,14 @@ def base_chara_experience_common_settle(
     if final_change_data != None:
         final_change_data.experience.setdefault(experience_id, 0)
         final_change_data.experience[experience_id] += base_value
+
+    # 心理处女是经验驱动的派生认知；在经验统一入口刷新，避免各H指令分别接入时发生遗漏。
+    # 延迟导入用于隔离通用结算与Sex_System，防止启动阶段形成循环导入。
+    if final_character_id != 0:
+        from Script.System.Sex_System import mental_virginity
+
+        unconscious_flag = bool(
+            handle_premise.handle_unconscious_flag_ge_1(final_character_id)
+            or handle_premise.handle_self_time_stop_orgasm_relase(final_character_id)
+        )
+        mental_virginity.update_from_experience(final_character_id, experience_id, unconscious_flag)

--- a/Script/System/Sex_System/mental_virginity.py
+++ b/Script/System/Sex_System/mental_virginity.py
@@ -1,0 +1,523 @@
+"""部位心理处女系统。
+
+心理处女表示角色是否已经认识到某个快感部位经历过具有性意义的刺激。
+系统使用经验、意识与事后发现证据进行判断，并保存已经形成的认知，避免状态随污浊清除而倒退。
+"""
+
+from types import FunctionType
+from typing import Dict, Iterable, List, Set, Tuple
+
+from Script.Config import game_config
+from Script.Core import cache_control, game_type, get_text
+from Script.System.Sex_System import sex_knowledge
+
+
+cache: game_type.Cache = cache_control.cache
+"""游戏缓存数据。"""
+_: FunctionType = get_text._
+"""翻译接口。"""
+
+
+MENTAL_VIRGINITY_INTACT = 0
+"""没有已知性经历，心理处女保有。"""
+MENTAL_VIRGINITY_UNAWARE = 1
+"""客观上存在性经历，但角色尚未意识到。"""
+MENTAL_VIRGINITY_SUSPECTED = 2
+"""角色察觉到异常或性刺激，但尚未完全确认。"""
+MENTAL_VIRGINITY_LOST = 3
+"""角色已经明确理解该部位经历过具有性意义的刺激。"""
+
+
+_PART_FIRST_RECORD_IDS: Dict[int, Tuple[int, ...]] = {
+    0: (0, 1, 4, 5, 10, 11),
+    1: (3,),
+    2: (),
+    3: (),
+    4: (6,),
+    5: (8,),
+    6: (9,),
+    7: (7,),
+    21: (2, 15),
+    22: (12, 13, 14),
+    23: (),
+}
+"""快感状态编号到部位交初体验记录编号的映射。"""
+
+
+_BODY_EVIDENCE_TO_PART_IDS: Dict[int, Tuple[int, ...]] = {
+    0: (0,),
+    1: (0,),
+    2: (21,),
+    3: (1,),
+    4: (0,),
+    5: (0,),
+    6: (4,),
+    7: (7,),
+    8: (5,),
+    9: (6,),
+    10: (0,),
+    11: (0,),
+    12: (22,),
+    13: (22,),
+    14: (22,),
+    15: (21,),
+    16: (0,),
+    17: (0,),
+    18: (0,),
+}
+"""无意识期间身体污浊部位到心理处女快感部位的映射。"""
+
+
+_CLOTH_EVIDENCE_TO_PART_IDS: Dict[int, Tuple[int, ...]] = {
+    0: (0,),
+    1: (0,),
+    2: (0, 22),
+    3: (0,),
+    4: (21,),
+    5: (0, 1),
+    6: (1,),
+    7: (0,),
+    8: (0,),
+    9: (2, 4, 5, 6),
+    10: (0,),
+    11: (0,),
+    12: (0,),
+    13: (0,),
+}
+"""无意识期间衣物污浊部位到可能被察觉的快感部位映射。"""
+
+
+_EXPERIENCE_TO_PART_IDS: Dict[int, Set[int]] = {}
+"""经验编号到受影响快感部位的反向索引。"""
+
+
+def _register_experience(experience_id: int, part_state_id: int) -> None:
+    """
+    向经验反向索引登记一个部位。
+
+    Keyword arguments:
+    experience_id -- 经验编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    None -- 仅更新模块内部映射。
+    """
+    _EXPERIENCE_TO_PART_IDS.setdefault(experience_id, set()).add(part_state_id)
+
+
+# 反向索引覆盖基础、高潮、无意识、专属、理论和通用插入经验，供通用经验结算入口快速筛选。
+for _part_id, (_base_id, _climax_id) in sex_knowledge._PART_BASE_EXPERIENCE.items():
+    _register_experience(_base_id, _part_id)
+    _register_experience(_climax_id, _part_id)
+    _register_experience(sex_knowledge._PART_UNCONSCIOUS_EXPERIENCE[_part_id], _part_id)
+    for _experience_id in sex_knowledge._PART_EXTRA_EXPERIENCE[_part_id]:
+        _register_experience(_experience_id, _part_id)
+    for _experience_id in sex_knowledge._PART_THEORY_EXPERIENCE[_part_id]:
+        _register_experience(_experience_id, _part_id)
+# 通用插入经验只提供低权重知识，不作为任一具体部位实际发生性经历的证据，
+# 因此不登记到心理处女的经验触发索引中。
+
+
+def _get_character_data(character_id: int):
+    """
+    安全读取角色数据。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+
+    Return arguments:
+    Character|None -- 角色数据，不存在时为None。
+    """
+    if cache is None or not isinstance(character_id, int):
+        return None
+    return cache.character_data.get(character_id)
+
+
+def _get_record_dict(character_data: game_type.Character) -> dict:
+    """
+    获取角色心理处女认知记录并兼容旧存档异常字段。
+
+    Keyword arguments:
+    character_data -- 角色数据对象。
+
+    Return arguments:
+    dict -- 可写入的心理处女认知字典。
+    """
+    record_dict = getattr(character_data, "mental_virginity", None)
+    if not isinstance(record_dict, dict):
+        record_dict = {}
+        character_data.mental_virginity = record_dict
+    return record_dict
+
+
+def is_part_applicable(character_id: int, part_state_id: int) -> bool:
+    """
+    判断指定快感部位是否适用于角色自身的心理处女显示。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 是否适用。通用部位始终适用，生殖器官按性别、兽部按相关身体素质判断。
+    """
+    character_data = _get_character_data(character_id)
+    if character_data is None or not sex_knowledge.is_supported_part(part_state_id):
+        return False
+    if character_data.sex == 0 and part_state_id in {2, 4, 7}:
+        return False
+    if character_data.sex == 1 and part_state_id == 3:
+        return False
+    if part_state_id == 22:
+        talent_data = getattr(character_data, "talent", {})
+        return isinstance(talent_data, dict) and any(talent_data.get(talent_id, 0) for talent_id in (111, 112, 113, 114, 115, 116))
+    return True
+
+
+def _has_first_record(character_data: game_type.Character, part_state_id: int) -> bool:
+    """
+    判断指定部位是否存在初体验或高潮履历。
+
+    Keyword arguments:
+    character_data -- 角色数据对象。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 是否存在可证明实际经历的履历。
+    """
+    first_record = getattr(character_data, "first_record", None)
+    if first_record is None:
+        return False
+    # 初吻使用独立字段保存，不在first_part_sex_dict中；它同样是口喉部位的明确经历。
+    if part_state_id == 21 and getattr(first_record, "first_kiss_id", -1) != -1:
+        return True
+    part_record_dict = getattr(first_record, "first_part_sex_dict", {})
+    if isinstance(part_record_dict, dict) and any(record_id in part_record_dict for record_id in _PART_FIRST_RECORD_IDS.get(part_state_id, ())):
+        return True
+    for record_name in ("first_strong_orgasm_dict", "first_super_orgasm_dict"):
+        record_dict = getattr(first_record, record_name, {})
+        if isinstance(record_dict, dict) and part_state_id in record_dict:
+            return True
+    return False
+
+
+def _has_confirmed_actual_experience(character_data: game_type.Character, part_state_id: int, summary: dict) -> bool:
+    """
+    判断指定部位是否存在足以证明实际性经历的数据。
+
+    绝顶经验不单独作为证明：部分旧存档会仅残留口喉、心理绝顶计数，却没有对应的
+    基础经验、行为经验或初体验履历。将这种孤立计数直接视为性经历会造成心理处女误判。
+
+    Keyword arguments:
+    character_data -- 角色数据对象。
+    part_state_id -- 快感状态编号。
+    summary -- 性知识模块生成的经验构成。
+
+    Return arguments:
+    bool -- 是否存在基础经历、无意识经历、明确行为经历或初体验履历。
+    """
+    return (
+        summary.get("base", 0) > 0
+        or summary.get("unconscious", 0) > 0
+        or summary.get("extra", 0) > 0
+        or _has_first_record(character_data, part_state_id)
+    )
+
+
+def _get_derived_state(character_id: int, part_state_id: int) -> int:
+    """
+    根据累计数据保守推导心理处女状态，用于新角色和旧存档兜底。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    int -- 推导出的心理处女状态。
+    """
+    character_data = _get_character_data(character_id)
+    summary = sex_knowledge.get_part_experience_summary(character_id, part_state_id)
+    if character_data is None or not summary:
+        return MENTAL_VIRGINITY_INTACT
+
+    # 理论知识本身不会使心理处女失去；孤立的旧绝顶计数也不足以证明实际性经历。
+    has_actual_experience = _has_confirmed_actual_experience(character_data, part_state_id, summary)
+    if not has_actual_experience:
+        return MENTAL_VIRGINITY_INTACT
+
+    knowledge_level = sex_knowledge.get_part_knowledge_level(character_id, part_state_id)
+    has_conscious_experience = any(summary[key] > 0 for key in ("conscious", "conscious_climax", "conscious_extra"))
+    if has_conscious_experience:
+        if knowledge_level >= sex_knowledge.KNOWLEDGE_LEVEL_BASIC:
+            return MENTAL_VIRGINITY_LOST
+        return MENTAL_VIRGINITY_SUSPECTED
+    return MENTAL_VIRGINITY_UNAWARE
+
+
+def get_part_mental_virginity_state(character_id: int, part_state_id: int) -> int:
+    """
+    获取角色指定快感部位的心理处女状态。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    int -- 0保有、1无自觉、2怀疑、3已失去；无效参数按保有处理。
+    """
+    character_data = _get_character_data(character_id)
+    if character_data is None or not sex_knowledge.is_supported_part(part_state_id):
+        return MENTAL_VIRGINITY_INTACT
+    record_dict = _get_record_dict(character_data)
+    try:
+        recorded_state = int(record_dict.get(part_state_id, MENTAL_VIRGINITY_INTACT))
+    except (TypeError, ValueError):
+        recorded_state = MENTAL_VIRGINITY_INTACT
+    recorded_state = max(MENTAL_VIRGINITY_INTACT, min(recorded_state, MENTAL_VIRGINITY_LOST))
+    return max(recorded_state, _get_derived_state(character_id, part_state_id))
+
+
+def record_part_mental_virginity_state(character_id: int, part_state_id: int, state: int) -> int:
+    """
+    固化角色已经形成的心理处女认知；普通流程只允许状态前进，避免清洗或换装后倒退。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+    state -- 要记录的状态编号。
+
+    Return arguments:
+    int -- 写入后的状态；参数无效时返回保有。
+    """
+    character_data = _get_character_data(character_id)
+    if character_data is None or not sex_knowledge.is_supported_part(part_state_id):
+        return MENTAL_VIRGINITY_INTACT
+    try:
+        state = int(state)
+    except (TypeError, ValueError):
+        state = MENTAL_VIRGINITY_INTACT
+    state = max(MENTAL_VIRGINITY_INTACT, min(state, MENTAL_VIRGINITY_LOST))
+    record_dict = _get_record_dict(character_data)
+    current_state = get_part_mental_virginity_state(character_id, part_state_id)
+    final_state = max(current_state, state)
+    if final_state > MENTAL_VIRGINITY_INTACT:
+        record_dict[part_state_id] = final_state
+    return final_state
+
+
+def update_from_experience(character_id: int, experience_id: int, unconscious: bool = False) -> None:
+    """
+    在经验结算后刷新受影响部位的心理处女认知。
+
+    Keyword arguments:
+    character_id -- 获得经验的角色编号。
+    experience_id -- 本次增加的经验编号。
+    unconscious -- 本次经验是否发生于无意识状态。
+
+    Return arguments:
+    None -- 仅更新角色的认知记录。
+    """
+    character_data = _get_character_data(character_id)
+    if character_data is None or character_id == 0:
+        return
+    experience_config = game_config.config_experience.get(experience_id)
+    if experience_config is None:
+        return
+    experience_type = experience_config.type
+    for part_state_id in _EXPERIENCE_TO_PART_IDS.get(experience_id, set()):
+        # 理论经验只会让角色重新思考已有经历，不会单独制造一次“失去”。
+        if experience_type == 12:
+            if get_part_mental_virginity_state(character_id, part_state_id) == MENTAL_VIRGINITY_UNAWARE:
+                if sex_knowledge.get_part_knowledge_level(character_id, part_state_id) >= sex_knowledge.KNOWLEDGE_LEVEL_BASIC:
+                    record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_SUSPECTED)
+            continue
+        # 旧存档和少数结算路径可能只有绝顶计数而没有对应的基础或行为经验。
+        # 先等待同次行为的明确经验结算，再推进心理处女，避免仅凭孤立绝顶计数误判。
+        if experience_type == 2:
+            summary = sex_knowledge.get_part_experience_summary(character_id, part_state_id)
+            if not _has_confirmed_actual_experience(character_data, part_state_id, summary):
+                continue
+        if unconscious or experience_type == 4:
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_UNAWARE)
+            continue
+        knowledge_level = sex_knowledge.get_part_knowledge_level(character_id, part_state_id)
+        if knowledge_level >= sex_knowledge.KNOWLEDGE_LEVEL_BASIC:
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_LOST)
+        else:
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_SUSPECTED)
+
+
+def record_unconscious_discovery(character_id: int, body_part_ids: Iterable[int], cloth_part_ids: Iterable[int]) -> None:
+    """
+    记录角色恢复意识后从身体和衣物污浊中发现的性经历证据。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    body_part_ids -- 无意识期间出现精液的身体部位编号。
+    cloth_part_ids -- 无意识期间出现精液的衣物部位编号。
+
+    Return arguments:
+    None -- 根据知识等级将相关部位推进至怀疑或已失去。
+    """
+    strong_evidence_part_ids: Set[int] = set()
+    weak_evidence_part_ids: Set[int] = {23}
+    for body_part_id in body_part_ids:
+        strong_evidence_part_ids.update(_BODY_EVIDENCE_TO_PART_IDS.get(body_part_id, ()))
+    for cloth_part_id in cloth_part_ids:
+        weak_evidence_part_ids.update(_CLOTH_EVIDENCE_TO_PART_IDS.get(cloth_part_id, ()))
+    # 身体上的直接证据可以在知识充分时形成确认。
+    for part_state_id in strong_evidence_part_ids:
+        if not is_part_applicable(character_id, part_state_id):
+            continue
+        knowledge_level = sex_knowledge.get_part_knowledge_level(character_id, part_state_id)
+        if knowledge_level >= sex_knowledge.KNOWLEDGE_LEVEL_BASIC:
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_LOST)
+        else:
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_SUSPECTED)
+    # 衣物污浊和服装失窃只能说明可能发生过性行为，无法确认具体部位，最多推进到怀疑。
+    for part_state_id in weak_evidence_part_ids:
+        if is_part_applicable(character_id, part_state_id):
+            record_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_SUSPECTED)
+
+
+def get_mental_virginity_state_name(state: int) -> str:
+    """
+    获取可翻译的心理处女状态名称。
+
+    Keyword arguments:
+    state -- 心理处女状态编号。
+
+    Return arguments:
+    str -- 对应状态名称，异常值按“保有”处理。
+    """
+    state_name_dict = {
+        MENTAL_VIRGINITY_INTACT: _("保有"),
+        MENTAL_VIRGINITY_UNAWARE: _("无自觉"),
+        MENTAL_VIRGINITY_SUSPECTED: _("怀疑"),
+        MENTAL_VIRGINITY_LOST: _("已失去"),
+    }
+    try:
+        state = int(state)
+    except (TypeError, ValueError):
+        state = MENTAL_VIRGINITY_INTACT
+    return state_name_dict.get(state, state_name_dict[MENTAL_VIRGINITY_INTACT])
+
+
+def get_part_mental_virginity_name(character_id: int, part_state_id: int) -> str:
+    """
+    获取角色指定部位的心理处女状态名称。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    str -- 可直接用于属性页或口上的状态名称。
+    """
+    return get_mental_virginity_state_name(get_part_mental_virginity_state(character_id, part_state_id))
+
+
+def is_part_mental_virginity_state(character_id: int, part_state_id: int, state: int) -> bool:
+    """
+    判断角色指定部位是否处于给定心理处女状态，供口上和事件前提调用。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+    state -- 要匹配的心理处女状态。
+
+    Return arguments:
+    bool -- 当前状态是否与给定状态相同。
+    """
+    return get_part_mental_virginity_state(character_id, part_state_id) == state
+
+
+def is_part_mental_virginity_intact(character_id: int, part_state_id: int) -> bool:
+    """
+    判断角色指定部位的心理处女是否处于“保有”。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 仅“保有”状态返回True。
+    """
+    return is_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_INTACT)
+
+
+def is_part_mental_virginity_unaware(character_id: int, part_state_id: int) -> bool:
+    """
+    判断角色指定部位的心理处女是否处于“无自觉”。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 仅“无自觉”状态返回True。
+    """
+    return is_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_UNAWARE)
+
+
+def is_part_mental_virginity_suspected(character_id: int, part_state_id: int) -> bool:
+    """
+    判断角色指定部位的心理处女是否处于“怀疑”。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 仅“怀疑”状态返回True。
+    """
+    return is_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_SUSPECTED)
+
+
+def is_part_mental_virginity_lost(character_id: int, part_state_id: int) -> bool:
+    """
+    判断角色指定部位的心理处女是否处于“已失去”。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 仅“已失去”状态返回True。
+    """
+    return is_part_mental_virginity_state(character_id, part_state_id, MENTAL_VIRGINITY_LOST)
+
+
+def iter_character_mental_virginity(character_id: int, include_inapplicable: bool = False) -> Iterable[Tuple[int, str, int]]:
+    """
+    遍历角色各快感部位的心理处女状态。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    include_inapplicable -- 是否包含角色自身不具备的器官和兽部。
+
+    Return arguments:
+    Iterable[Tuple[int, str, int]] -- 快感状态编号、部位名称、心理处女状态。
+    """
+    for part_state_id in sex_knowledge.get_supported_part_state_ids():
+        if not include_inapplicable and not is_part_applicable(character_id, part_state_id):
+            continue
+        if part_state_id not in game_config.config_character_state:
+            continue
+        yield part_state_id, game_config.config_character_state[part_state_id].name, get_part_mental_virginity_state(character_id, part_state_id)
+
+
+def get_character_mental_virginity_text(character_id: int) -> List[str]:
+    """
+    构建属性页面使用的心理处女状态文本。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+
+    Return arguments:
+    list[str] -- 角色适用部位的心理处女状态文本。
+    """
+    return [
+        _("{0}:{1}").format(part_name, get_mental_virginity_state_name(state))
+        for _part_state_id, part_name, state in iter_character_mental_virginity(character_id)
+    ]

--- a/Script/System/Sex_System/sex_knowledge.py
+++ b/Script/System/Sex_System/sex_knowledge.py
@@ -1,0 +1,357 @@
+"""性知识推导模块。
+
+性知识是由角色已有的性经验实时推导出的派生数据，不单独写入存档。
+部位范围与高潮系统保持一致，包含普通部位、口喉、兽部和心理部位。
+"""
+
+from types import FunctionType
+from typing import Dict, Iterable, List, Tuple
+
+from Script.Config import game_config
+from Script.Core import cache_control, game_type, get_text
+
+
+cache: game_type.Cache = cache_control.cache
+"""游戏缓存数据。"""
+_: FunctionType = get_text._
+"""翻译接口。"""
+
+
+# 与 Script.Settle.orgasm_settle.orgasm_part_to_state_id 保持同一套状态编号。
+# 这里不直接导入 orgasm_settle，避免性知识模块与高潮结算模块形成循环导入。
+KNOWLEDGE_PART_STATE_MAP: Dict[str, int] = {
+    "s": 0,
+    "b": 1,
+    "c": 2,
+    "p": 3,
+    "v": 4,
+    "a": 5,
+    "u": 6,
+    "w": 7,
+    "m": 21,
+    "f": 22,
+    "h": 23,
+}
+"""可独立产生快感或高潮的部位标识到快感状态编号的映射。"""
+
+KNOWLEDGE_LEVEL_NONE = 0
+"""完全不了解。"""
+KNOWLEDGE_LEVEL_LOW = 1
+"""略有了解。"""
+KNOWLEDGE_LEVEL_BASIC = 2
+"""基本了解。"""
+KNOWLEDGE_LEVEL_FAMILIAR = 3
+"""熟悉。"""
+KNOWLEDGE_LEVEL_FULL = 4
+"""充分了解。"""
+
+_SCORE_SCALE = 10
+"""知识分数倍率，用整数表示百分比权重，避免浮点误差。"""
+_GENERAL_INSERTION_WEIGHT = 2
+"""通用插入经验的权重，2/10即专属经验的20%。"""
+
+
+_PART_BASE_EXPERIENCE: Dict[int, Tuple[int, int]] = {
+    0: (0, 10),
+    1: (1, 11),
+    2: (2, 12),
+    3: (3, 13),
+    4: (4, 14),
+    5: (5, 15),
+    6: (6, 16),
+    7: (7, 17),
+    21: (153, 156),  # 口喉经验
+    22: (154, 157),  # 兽部经验
+    23: (155, 158),  # 心理经验
+}
+"""各快感部位对应的基础经验和高潮经验编号。"""
+
+
+_PART_UNCONSCIOUS_EXPERIENCE: Dict[int, int] = {
+    0: 70,
+    1: 71,
+    2: 72,
+    3: 73,
+    4: 74,
+    5: 75,
+    6: 76,
+    7: 77,
+    21: 159,
+    22: 160,
+    23: 161,
+}
+"""各快感部位对应的无意识经验编号。"""
+
+
+_PART_EXTRA_EXPERIENCE: Dict[int, Tuple[int, ...]] = {
+    0: (),
+    1: (43,),  # 乳交
+    2: (),
+    3: (),
+    4: (61, 65),
+    5: (62, 66),
+    6: (63, 67),
+    7: (64, 68),
+    21: (40, 42),  # 接吻、口交
+    22: (48,),  # 兽部交
+    23: (30, 31, 32, 33, 34, 35, 36, 37),  # 心理快感经验
+}
+"""各部位可用于推导性知识的补充经验编号。"""
+
+
+_GENERAL_INSERTION_PART_IDS = {3, 4, 5, 6, 7}
+"""会受到通用插入经验影响的部位状态编号。"""
+
+
+_PART_THEORY_EXPERIENCE: Dict[int, Tuple[int, ...]] = {
+    0: (),
+    1: (173,),  # 乳交理论经验
+    2: (),
+    3: (170, 174, 176),  # 手交、性交、榨精理论经验
+    4: (174,),  # 性交理论经验
+    5: (175,),  # 肛交理论经验
+    6: (),
+    7: (174,),  # 性交理论经验
+    21: (171,),  # 口交理论经验
+    22: (),
+    23: (),
+}
+"""各快感部位可直接使用的理论经验编号；没有明确对应关系的理论经验暂不强行分配。"""
+
+
+if set(KNOWLEDGE_PART_STATE_MAP.values()) != set(_PART_BASE_EXPERIENCE):
+    raise ValueError("性知识部位映射与经验映射不一致")
+if set(_PART_EXTRA_EXPERIENCE) != set(_PART_BASE_EXPERIENCE):
+    raise ValueError("性知识补充经验映射不完整")
+if set(_PART_THEORY_EXPERIENCE) != set(_PART_BASE_EXPERIENCE):
+    raise ValueError("性知识理论经验映射不完整")
+if set(_PART_UNCONSCIOUS_EXPERIENCE) != set(_PART_BASE_EXPERIENCE):
+    raise ValueError("性知识无意识经验映射不完整")
+
+
+def get_supported_part_state_ids() -> Tuple[int, ...]:
+    """
+    获取性知识系统支持的快感部位状态编号。
+
+    Return arguments:
+    tuple[int, ...] -- 支持的快感状态编号，顺序与高潮系统一致。
+    """
+    return tuple(KNOWLEDGE_PART_STATE_MAP.values())
+
+
+def is_supported_part(part_state_id: int) -> bool:
+    """
+    判断指定快感状态是否受性知识系统支持。
+
+    Keyword arguments:
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    bool -- 该状态是否属于性知识部位。
+    """
+    return isinstance(part_state_id, int) and part_state_id in _PART_BASE_EXPERIENCE
+
+
+def _get_experience_value(character_data: game_type.Character, experience_id: int) -> int:
+    """
+    读取角色指定经验值，并兼容旧存档缺少经验字段的情况。
+
+    Keyword arguments:
+    character_data -- 角色数据对象。
+    experience_id -- 经验编号。
+
+    Return arguments:
+    int -- 非负经验值。
+    """
+    experience_data = getattr(character_data, "experience", {})
+    if not isinstance(experience_data, dict):
+        return 0
+    try:
+        return max(0, int(experience_data.get(experience_id, 0)))
+    except (TypeError, ValueError, AttributeError):
+        return 0
+
+
+def get_part_experience_summary(character_id: int, part_state_id: int) -> dict:
+    """
+    获取指定快感部位的经验构成，供性知识与心理处女系统共同使用。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    dict -- 包含基础、清醒估算、无意识、高潮、专属、理论和通用插入经验的字典；参数无效时返回空字典。
+    """
+    if not is_supported_part(part_state_id) or cache is None:
+        return {}
+    character_data = cache.character_data.get(character_id)
+    if character_data is None:
+        return {}
+
+    base_experience_id, climax_experience_id = _PART_BASE_EXPERIENCE[part_state_id]
+    base_value = _get_experience_value(character_data, base_experience_id)
+    unconscious_value = _get_experience_value(character_data, _PART_UNCONSCIOUS_EXPERIENCE[part_state_id])
+    conscious_value = max(0, base_value - unconscious_value)
+    # 基础经验会同时累计清醒与无意识经历，用其比例保守估算高潮、性交和扩张经验中的可认知部分。
+    if base_value > 0:
+        conscious_ratio = min(1.0, conscious_value / base_value)
+    elif unconscious_value > 0:
+        conscious_ratio = 0.0
+    else:
+        conscious_ratio = 1.0
+    climax_value = _get_experience_value(character_data, climax_experience_id)
+    extra_value = sum(_get_experience_value(character_data, experience_id) for experience_id in _PART_EXTRA_EXPERIENCE.get(part_state_id, ()))
+    general_insertion_value = _get_experience_value(character_data, 60) if part_state_id in _GENERAL_INSERTION_PART_IDS else 0
+    return {
+        "base": base_value,
+        # 原结算会在无意识时同时增加基础经验和无意识经验，因此二者相减可保守估算清醒经验。
+        "conscious": conscious_value,
+        "unconscious": unconscious_value,
+        "climax": climax_value,
+        "conscious_climax": int(climax_value * conscious_ratio),
+        "extra": extra_value,
+        "conscious_extra": int(extra_value * conscious_ratio),
+        "theory": sum(_get_experience_value(character_data, experience_id) for experience_id in _PART_THEORY_EXPERIENCE.get(part_state_id, ())),
+        "general_insertion": general_insertion_value,
+        "conscious_general_insertion": int(general_insertion_value * conscious_ratio),
+    }
+
+
+def get_part_knowledge_score(character_id: int, part_state_id: int) -> int:
+    """
+    根据已有性经验计算指定快感部位的原始知识分数。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号，必须属于支持的部位集合。
+
+    Return arguments:
+    int -- 非负知识分数。该分数是内部推导值，不直接展示给玩家。
+    """
+    if not is_supported_part(part_state_id) or cache is None:
+        return 0
+    character_data = cache.character_data.get(character_id)
+    experience_summary = get_part_experience_summary(character_id, part_state_id)
+    if character_data is None or not experience_summary:
+        return 0
+
+    # 只有可与无意识记录区分开的清醒经验按完整权重形成知识；无意识经验作为事实保留，但不直接增加认知。
+    score = experience_summary["conscious"] * _SCORE_SCALE
+    # 高潮经验只有在同部位还存在基础经验或明确行为经验时才计入性知识。
+    # 高品质食物等非性行为也可能产生口喉、心理绝顶；孤立绝顶记录不能证明角色获得了对应的性知识。
+    confirmed_practical_value = experience_summary["conscious"] + experience_summary["conscious_extra"]
+    if confirmed_practical_value > 0:
+        conscious_climax_value = experience_summary["conscious_climax"]
+        if part_state_id in {21, 23}:
+            # 口喉和心理绝顶可能由高品质食物产生；即使日后新增一次真实经历，
+            # 也不能让此前积累的全部非性行为绝顶突然转化为性知识。
+            conscious_climax_value = min(conscious_climax_value, confirmed_practical_value)
+        score += conscious_climax_value * _SCORE_SCALE * 2
+    score += experience_summary["conscious_extra"] * _SCORE_SCALE
+
+    # 理论经验直接代表对相关性行为的理解，权重与高潮经验相同。
+    score += experience_summary["theory"] * _SCORE_SCALE * 2
+
+    # 插入总经验能提供通用认识，但仅按专属经验的20%影响具体部位，避免不同插入部位相互污染。
+    score += experience_summary["conscious_general_insertion"] * _GENERAL_INSERTION_WEIGHT
+
+    # “性无知”是已有的粗粒度认知状态。它不抹除事实经验，只降低由经验推导出的理解程度。
+    if getattr(character_data, "talent", {}).get(222, 0):
+        score //= 2
+    return max(0, score)
+
+
+def get_part_knowledge_level(character_id: int, part_state_id: int) -> int:
+    """
+    获取角色对指定快感部位的性知识等级。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    int -- 0 到 4 的知识等级，0 表示完全不了解。
+    """
+    score = get_part_knowledge_score(character_id, part_state_id)
+    if score <= 0:
+        return KNOWLEDGE_LEVEL_NONE
+    if score <= 2 * _SCORE_SCALE:
+        return KNOWLEDGE_LEVEL_LOW
+    if score <= 8 * _SCORE_SCALE:
+        return KNOWLEDGE_LEVEL_BASIC
+    if score <= 20 * _SCORE_SCALE:
+        return KNOWLEDGE_LEVEL_FAMILIAR
+    return KNOWLEDGE_LEVEL_FULL
+
+
+def get_knowledge_level_name(level: int) -> str:
+    """
+    获取可翻译的性知识等级名称。
+
+    Keyword arguments:
+    level -- 性知识等级。
+
+    Return arguments:
+    str -- 等级对应的文本，异常等级按“完全不了解”处理。
+    """
+    level_name_dict = {
+        KNOWLEDGE_LEVEL_NONE: _("完全不了解"),
+        KNOWLEDGE_LEVEL_LOW: _("略有了解"),
+        KNOWLEDGE_LEVEL_BASIC: _("基本了解"),
+        KNOWLEDGE_LEVEL_FAMILIAR: _("熟悉"),
+        KNOWLEDGE_LEVEL_FULL: _("充分了解"),
+    }
+    try:
+        level = int(level)
+    except (TypeError, ValueError):
+        level = KNOWLEDGE_LEVEL_NONE
+    return level_name_dict.get(level, level_name_dict[KNOWLEDGE_LEVEL_NONE])
+
+
+def get_part_knowledge_name(character_id: int, part_state_id: int) -> str:
+    """
+    获取指定部位的可翻译性知识等级名称。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+    part_state_id -- 快感状态编号。
+
+    Return arguments:
+    str -- 性知识等级名称。
+    """
+    level = get_part_knowledge_level(character_id, part_state_id)
+    return get_knowledge_level_name(level)
+
+
+def iter_part_knowledge(character_id: int) -> Iterable[Tuple[int, str, int]]:
+    """
+    遍历角色所有支持的快感部位及其知识等级。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+
+    Return arguments:
+    Iterable[Tuple[int, str, int]] -- 状态编号、部位名称、知识等级。
+    """
+    for part_state_id in get_supported_part_state_ids():
+        if part_state_id not in game_config.config_character_state:
+            continue
+        part_name = game_config.config_character_state[part_state_id].name
+        yield part_state_id, part_name, get_part_knowledge_level(character_id, part_state_id)
+
+
+def get_character_knowledge_text(character_id: int) -> List[str]:
+    """
+    构建属性页面使用的性知识文本。
+
+    Keyword arguments:
+    character_id -- 角色编号。
+
+    Return arguments:
+    list[str] -- 每个支持部位一行的可翻译文本。
+    """
+    knowledge_text: List[str] = []
+    for _part_state_id, part_name, level in iter_part_knowledge(character_id):
+        knowledge_text.append(_("{0}:{1}").format(part_name, get_knowledge_level_name(level)))
+    return knowledge_text

--- a/Script/UI/Moudle/draw.py
+++ b/Script/UI/Moudle/draw.py
@@ -838,9 +838,11 @@ class LittleTitleLineDraw:
     line -- 用于绘制线条的文本
     style -- 线条样式
     title_style -- 标题样式
+    tooltip -- 鼠标悬停在标题上时显示的说明文本
+    center_title -- 是否将标题放在整条分隔线的中央
     """
 
-    def __init__(self, title: str, width: int, line: str = "=", style="standard", title_style="sontitle"):
+    def __init__(self, title: str, width: int, line: str = "=", style="standard", title_style="sontitle", tooltip: str = "", center_title: bool = False):
         """初始化绘制对象"""
         self.title = title
         """ 标题 """
@@ -852,6 +854,10 @@ class LittleTitleLineDraw:
         """ 线条默认样式 """
         self.title_style = title_style
         """ 标题样式 """
+        self.tooltip = tooltip
+        """ 鼠标悬停在标题上时显示的说明文本 """
+        self.center_title = center_title
+        """ 是否将标题放在整条分隔线的中央 """
         self.line_feed: bool = True
         """ 线尾换行 """
 
@@ -861,7 +867,13 @@ class LittleTitleLineDraw:
         # title_draw.width = self.width
         title_draw.text = self.title
         title_draw.style = self.title_style
-        line_a_width = int(self.width / 16) - len(title_draw)
+        title_draw.tooltip = self.tooltip
+        if self.center_title:
+            # 旧布局未设置标题宽度，len(title_draw) 会回传 0；居中时需先计入标题的实际宽度。
+            title_draw.width = self.width
+            line_a_width = int((self.width - len(title_draw)) / 2)
+        else:
+            line_a_width = int(self.width / 16) - len(title_draw)
         if line_a_width < 0:
             line_a_width = 0
         line_a = NormalDraw()

--- a/Script/UI/Panel/see_character_info_panel.py
+++ b/Script/UI/Panel/see_character_info_panel.py
@@ -15,6 +15,7 @@ from Script.Config import game_config, normal_config
 from Script.Design import attr_text, map_handle, attr_calculation, game_time, instuct_judege, character_image
 from Script.UI.Panel import body_info_panel, character_info_head
 from Script.System.First_Record_System import first_record_panel
+from Script.System.Sex_System import mental_virginity, sex_knowledge
 
 panel_info_data = {}
 
@@ -172,11 +173,13 @@ class See_Character_Detailed_Attributes_Panel:
         head_draw = character_info_head.CharacterInfoHead(character_id, width)
         abi_draw = CharacterabiText(character_id, width)
         experience_draw = CharacterExperienceText(character_id, width, 8, 0)
+        knowledge_draw = CharacterSexKnowledgeText(character_id, width, 4)
         juel_draw = CharacterJuelText(character_id, width, 8, 0)
         self.draw_list: List[draw.NormalDraw] = [
             head_draw,
             abi_draw,
             experience_draw,
+            knowledge_draw,
             juel_draw,
         ]
         """ 绘制的面板列表 """
@@ -201,6 +204,7 @@ class SeeCharacterThirdPanel:
         """初始化绘制对象"""
         head_draw = character_info_head.CharacterInfoHead(character_id, width)
         body_draw = body_info_panel.CharacterBodyText(character_id, width, 8, 0)
+        mental_virginity_draw = CharacterMentalVirginityText(character_id, width, 4)
         ability_draw = PlayerAbilityText(character_id, width, 8, 0)
         if character_id == 0:
             self.draw_list: List[draw.NormalDraw] = [
@@ -211,6 +215,7 @@ class SeeCharacterThirdPanel:
             self.draw_list: List[draw.NormalDraw] = [
                 head_draw,
                 body_draw,
+                mental_virginity_draw,
             ]
         """ 绘制的面板列表 """
         self.return_list: List[str] = []
@@ -817,6 +822,96 @@ class CharacterImage:
             now_draw_1.width = 1
             now_draw_1.draw()
             flow_handle.print_image_cmd(self.image_name, "立绘按钮")
+
+
+class CharacterMentalVirginityText:
+    """
+    显示角色各快感部位的心理处女状态。
+
+    Keyword arguments:
+    character_id -- 角色id
+    width -- 面板最大宽度
+    column -- 每行显示的部位数量
+    """
+
+    def __init__(self, character_id: int, width: int, column: int = 4):
+        """初始化心理处女显示对象。"""
+        self.character_id = character_id
+        """要绘制的角色id。"""
+        self.width = width
+        """面板最大宽度。"""
+        self.column = max(1, column)
+        """每行显示的部位数量。"""
+        self.draw_list: List = []
+        """绘制对象列表。"""
+        self.return_list: List[str] = []
+        """当前面板监听的按钮列表；心理处女仅显示文本，因此保持为空。"""
+
+        mental_virginity_tooltip = _(
+            "心理处女表示角色主观上是否认定某个可获得性快感的部位仍保有第一次。"
+            "系统会综合实际经历、当时的意识状态、事后发现的身体或衣物痕迹以及相应的性知识进行判断。"
+            "它与肉体处女状态不同；“无自觉”表示角色尚不知道发生过相关经历，“怀疑”表示角色已有线索但尚未确认。"
+        )
+        # 标题在整条分隔线上居中，悬浮说明仍只覆盖标题文本。
+        title_draw = draw.LittleTitleLineDraw(_("心理处女"), width, ":", tooltip=mental_virginity_tooltip, center_title=True)
+        self.draw_list.append(title_draw)
+        info_draw = panel.CenterDrawTextListPanel()
+        info_draw.set(mental_virginity.get_character_mental_virginity_text(character_id), width, self.column)
+        self.draw_list.extend(info_draw.draw_list)
+
+    def draw(self):
+        """绘制心理处女状态。"""
+        line_feed.draw()
+        for label in self.draw_list:
+            if isinstance(label, list):
+                for value in label:
+                    value.draw()
+                line_feed.draw()
+            else:
+                label.draw()
+
+
+class CharacterSexKnowledgeText:
+    """
+    显示角色性知识面板对象。
+
+    性知识由 Sex_System.sex_knowledge 根据已有经验实时推导，不写入存档，
+    因此旧存档也可以直接显示该项目。
+    Keyword arguments:
+    character_id -- 角色id
+    width -- 面板最大宽度
+    column -- 每行显示的部位数量
+    """
+
+    def __init__(self, character_id: int, width: int, column: int = 4):
+        """初始化性知识显示对象。"""
+        self.character_id = character_id
+        """要绘制的角色id。"""
+        self.width = width
+        """面板最大宽度。"""
+        self.column = max(1, column)
+        """每行显示的部位数量。"""
+        self.draw_list: List = []
+        """绘制对象列表。"""
+
+        # 只显示高潮系统登记过的部位，保证普通部位、口喉、兽部和心理部位使用同一范围。
+        knowledge_text_list = sex_knowledge.get_character_knowledge_text(character_id)
+        title_draw = draw.LittleTitleLineDraw(_("性知识"), width, ":")
+        self.draw_list.append(title_draw)
+        info_draw = panel.CenterDrawTextListPanel()
+        info_draw.set(knowledge_text_list, width, self.column)
+        self.draw_list.extend(info_draw.draw_list)
+
+    def draw(self):
+        """绘制性知识内容。"""
+        line_feed.draw()
+        for label in self.draw_list:
+            if isinstance(label, list):
+                for value in label:
+                    value.draw()
+                line_feed.draw()
+            else:
+                label.draw()
 
 
 class CharacterExperienceText:


### PR DESCRIPTION
## 修改背景

本 PR 初步实装“分部位性知识”和“分部位心理处女”系统。
#275 中第二条的初步实现尝试

心理处女不作为新的素质添加，而是绑定到各个可通过 H 刺激获得快感的部位。角色会综合实际经历、经历发生时的意识状态、身体及衣物证据，以及对相关行为的性知识，判断自己是否已经失去对应部位的心理处女。

## 主要修改

### 1. 分部位性知识

新增 `Script/System/Sex_System/sex_knowledge.py`，根据角色现有经验动态推导各部位的性知识，不额外保存重复数据。

目前覆盖以下部位：

- 皮肤
- 胸部
- 阴蒂
- 阴茎
- 阴道
- 肛门
- 尿道
- 子宫
- 口喉
- 兽部
- 心理

性知识主要根据以下数据计算：

- 对应部位的有意识经验
- 对应技巧或实践经验
- 有效的有意识绝顶经验
- 对应理论经验
- 少量通用性交经验

当前的简化计算方式为：

`K = 有意识部位经验 + 技巧或实践经验 + 2 × 有效有意识绝顶经验 + 2 × 理论经验 + 20% × 有意识通用性交经验`

拥有“性无知”素质时，最终结果会降低。

根据 K 值划分为：

- K = 0：无知
- 0 < K <= 2：略知
- 2 < K <= 8：基础
- 8 < K <= 20：熟悉
- K > 20：精通

为避免非性行为造成误判，只有绝顶记录、没有对应实践经验时，绝顶经验不会增加性知识。

其中口喉和心理绝顶可能由高品质食物产生，因此这两个部位的绝顶贡献还会受到实际实践经验数量限制，避免进食产生的历史绝顶记录被错误识别为性知识。

通用性交经验仍然保留，但只以较低权重参与计算，避免其完全覆盖各部位之间的知识差异。

### 2. 分部位心理处女

新增 `Script/System/Sex_System/mental_virginity.py`，对每个适用部位分别判断心理处女状态。

目前分为四种状态：

- 保有：没有足以证明相关经历发生过的信息
- 无自觉：相关经历在无意识状态下发生，角色尚未察觉
- 怀疑：角色已经掌握部分线索，但知识或证据不足以确认
- 已失去：角色能够明确认知到相关经历已经发生

判定会综合以下信息：

- 实际部位经验
- 有意识与无意识经验
- 初次经历记录
- 身体残留或身体变化
- 衣物污浊
- 内衣或袜子被取走等间接证据
- 对应部位的性知识

大致判定顺序为：

- 没有已确认的实际经历：保有
- 只有无意识经历且尚未发现：无自觉
- 已有意识经历，但对应性知识不足：怀疑
- 已有意识经历，且对应性知识达到基础：已失去
- 无意识后发现身体证据，并拥有足够知识：已失去
- 只有间接衣物证据：最多判定为怀疑

理论知识本身不会直接导致心理处女丧失。

单独存在的绝顶经验也不会被视为实际经历已经发生，以避免进食、心理刺激或其他非性行为造成错误判断。

角色会根据身体条件显示适用部位：

- 男性不显示阴蒂、阴道和子宫
- 女性不显示阴茎
- 兽部只对具有对应身体特征的角色显示

### 3. 状态保存与旧存档兼容

在角色数据中增加心理处女状态记录。

性知识由现有经验实时推导，不写入新的存档字段。

心理处女状态使用持久化记录，并提供旧存档兼容：

- 旧存档缺少该字段时自动使用默认值
- 遇到缺失或异常数据时自动修复
- 已经确认的心理状态不会因为经验数据暂时变化而自动倒退
- 无意识经验单独存在时可以正确推导为“无自觉”

### 4. 结算系统接入

在通用 NPC 经验结算完成后，统一更新心理处女状态，避免为每一条 H 指令分别添加更新逻辑。

在角色从无意识状态恢复，并检查身体或衣物变化时，会记录对应部位的发现结果。

内衣或袜子被取走等信息会在原数据被清除前完成记录，避免证据丢失。

### 5. 后续开发接口

提供了明确的状态查询与更新接口，包括：

- 查询指定部位当前状态
- 判断指定部位是否保有
- 判断指定部位是否无自觉
- 判断指定部位是否处于怀疑
- 判断指定部位是否已经失去
- 主动记录心理处女状态
- 根据经验更新状态
- 记录无意识后的身体或衣物发现
- 查询部位是否适用于当前角色
- 获取用于界面显示的状态文本

未保留含义容易混淆的 `has_part_mental_virginity()` 接口。

该接口会同时把“保有”“无自觉”和“怀疑”返回为真，容易让后续口上或事件开发者误以为它只表示“保有”。目前改为使用明确的状态查询接口，以降低误用风险。

### 6. 属性界面显示

在角色属性界面中增加以下内容：

- 在“能力、经验与宝珠”页面显示各部位性知识
- 在 NPC 的“肉体情况”页面显示各部位心理处女状态


## 兼容性说明

- 不把心理处女作为新的素质添加
- 不修改现有肉体处女系统
- 性知识不写入重复的存档数据
- 心理处女字段兼容旧存档
- 不增加 Debug 模式中的心理处女修改项
- 不直接增加口上、事件或具体前提
- 为后续口上、事件和前提开发保留明确接口

## 验证情况

已完成以下检查：

- 相关 Python 文件语法编译通过
- 新角色在没有相关经历时保持心理处女
- 有意识经历可以根据性知识判定为怀疑或已失去
- 只有无意识经验时判定为无自觉
- 无意识后发现身体或衣物证据时可以更新认知
- 理论知识不会单独造成心理处女丧失
- 单独绝顶记录不会被识别为实际性经历
- 进食产生的口喉及心理绝顶不会错误增加性知识
- 口喉和心理的历史绝顶不会被一次实践经验全部解锁
- 普通部位的正常绝顶经验仍按原定权重参与计算
- 男性、女性及兽部适用性判断正常
- 属性界面能够显示性知识与心理处女状态
- 心理处女标题能够居中显示并提供悬停说明
- 旧存档缺少新字段时可以正常读取

## 涉及文件

- `Script/Core/game_type.py`
- `Script/Design/handle_npc_ai_in_h.py`
- `Script/Settle/common_default.py`
- `Script/System/Sex_System/mental_virginity.py`
- `Script/System/Sex_System/sex_knowledge.py`
- `Script/UI/Moudle/draw.py`
- `Script/UI/Panel/see_character_info_panel.py`

## 后续开发方向

- 根据实际游玩反馈调整性知识权重和等级阈值
- 进一步区分经验的来源及发生时的意识状态
- 细化不同身体证据和衣物证据的可信程度
- 完善口喉、兽部和心理等特殊部位的知识来源
- 将部位与经验映射整理为更统一的公共配置
- 为规则调整提供版本化迁移或重新计算机制
- 增加更详细的界面状态说明
- 接入前提、事件及口上系统
- 补充对应翻译文本

以上，烦请审阅并提出意见
Appreciate your time and have a nice day: )