### PR TITLE
feature:使用Ctrl键快速跳过对话

### DIFF
--- a/Script/Core/flow_handle.py
+++ b/Script/Core/flow_handle.py
@@ -27,6 +27,11 @@ _web_module_loaded = False
 flow_handle_web = None
 """ Web版flow_handle模块的引用（延迟导入） """
 
+CTRL_SKIP_WAIT_DELAY = 0.1
+""" Ctrl长按快进时每个文本等待点的停顿秒数 """
+DEFAULT_SKIP_WAIT_DELAY = 0.001
+""" 右键与系统自动跳过时的原有停顿秒数 """
+
 
 def _is_web_mode():
     """
@@ -525,6 +530,34 @@ def askfor_int(list, print_order=False):
             io_init.era_print(order + "\n")
             io_init.era_print(_("您输入的选项无效，请重试\n"))
             continue
+
+
+def is_wait_skip_active() -> bool:
+    """
+    判断当前是否需要跳过被动文本等待。
+
+    参数：无
+    返回值：bool -- 右键、系统自动跳过或Ctrl长按任一状态生效时返回True
+    功能描述：统一管理各类文本等待跳过状态，避免Ctrl松开时误清除系统自身的跳过标志。
+    """
+    mouse_state = cache.wframe_mouse
+    return bool(mouse_state.w_frame_skip_wait_mouse or getattr(mouse_state, "w_frame_skip_wait_ctrl", 0))
+
+
+def get_wait_skip_delay() -> float:
+    """
+    获取当前文本快进状态的停顿时间。
+
+    参数：无
+    返回值：float -- 建议的停顿秒数；没有快进状态时返回0
+    功能描述：保留右键与系统跳过的原有高速节奏，并为Ctrl长按留出可以及时松键停止的间隔。
+    """
+    mouse_state = cache.wframe_mouse
+    if mouse_state.w_frame_skip_wait_mouse:
+        return DEFAULT_SKIP_WAIT_DELAY
+    if getattr(mouse_state, "w_frame_skip_wait_ctrl", 0):
+        return CTRL_SKIP_WAIT_DELAY
+    return 0.0
 
 
 def askfor_wait():

--- a/Script/Core/game_type.py
+++ b/Script/Core/game_type.py
@@ -30,6 +30,8 @@ class WFrameMouse:
     """ 等待玩家确认后逐行 """
     w_frame_skip_wait_mouse: int = 0
     """ 跳过等待输入后继续输出文本 """
+    w_frame_skip_wait_ctrl: int = 0
+    """ 按住Ctrl键时快速推进被动文本等待 """
 
 
 class NpcTem:

--- a/Script/Core/key_listion_event.py
+++ b/Script/Core/key_listion_event.py
@@ -7,6 +7,9 @@ wframe = main_frame.root
 cache: game_type.Cache = cache_control.cache
 """ 游戏缓存数据 """
 
+_pressed_ctrl_keys = set()
+""" 当前仍处于按下状态的左右Ctrl键名集合 """
+
 
 def _set_history_order(history_index: int):
     """
@@ -60,6 +63,82 @@ def on_wframe_listion():
     wframe.bind("<KP_Enter>", main_frame.send_input)
     wframe.bind("<Up>", key_up)
     wframe.bind("<Down>", key_down)
+    wframe.bind("<KeyPress-Control_L>", ctrl_press)
+    wframe.bind("<KeyRelease-Control_L>", ctrl_release)
+    wframe.bind("<KeyPress-Control_R>", ctrl_press)
+    wframe.bind("<KeyRelease-Control_R>", ctrl_release)
+    # FocusOut会在窗口内部焦点变化时同样触发，因此由空闲回调再判断游戏窗口是否真的失去焦点。
+    wframe.bind("<FocusOut>", ctrl_focus_out, add="+")
+
+
+def ctrl_press(event: Event):
+    """
+    开始Ctrl长按快进。
+
+    参数：event (Event) -- Tk键盘按下事件
+    返回值：无
+    功能描述：记录左右Ctrl的按下状态，结束逐字延迟，并解除当前正在进行的被动文本等待。
+    """
+    ctrl_key = getattr(event, "keysym", "Control_L")
+    _pressed_ctrl_keys.add(ctrl_key)
+    cache.wframe_mouse.w_frame_skip_wait_ctrl = 1
+    cache.text_wait = 0
+    # Ctrl长按明确表示希望快进；这里只改变等待状态，不向命令队列注入输入，因此不会自动选择菜单。
+    if not cache.wframe_mouse.w_frame_up:
+        set_wframe_up()
+
+
+def ctrl_release(event: Event):
+    """
+    处理Ctrl键松开事件。
+
+    参数：event (Event) -- Tk键盘松开事件
+    返回值：无
+    功能描述：移除已松开的Ctrl键，仅在左右Ctrl都松开后停止快进。
+    """
+    ctrl_key = getattr(event, "keysym", "Control_L")
+    _pressed_ctrl_keys.discard(ctrl_key)
+    cache.wframe_mouse.w_frame_skip_wait_ctrl = int(bool(_pressed_ctrl_keys))
+
+
+def clear_ctrl_skip_state():
+    """
+    清除Ctrl长按快进状态。
+
+    参数：无
+    返回值：无
+    功能描述：在窗口失去焦点且无法收到松键事件时防止Ctrl快进长期残留。
+    """
+    _pressed_ctrl_keys.clear()
+    cache.wframe_mouse.w_frame_skip_wait_ctrl = 0
+
+
+def _clear_ctrl_skip_if_window_inactive():
+    """
+    在Tk处理完当前焦点事件后检查游戏窗口是否真的失焦。
+
+    参数：无
+    返回值：无
+    功能描述：窗口内部的输入框与文本区切换不会停止快进，只在焦点离开整个应用时清理状态。
+    """
+    try:
+        if wframe.focus_displayof() is not None:
+            return
+    except Exception:
+        # 窗口销毁期间无法查询焦点时同样清理，避免运行时状态残留。
+        pass
+    clear_ctrl_skip_state()
+
+
+def ctrl_focus_out(event: Event):
+    """
+    安排窗口失焦后的Ctrl状态检查。
+
+    参数：event (Event) -- Tk焦点离开事件
+    返回值：无
+    功能描述：延迟到当前事件处理完成后再判断是应用失焦还是内部焦点切换。
+    """
+    wframe.after_idle(_clear_ctrl_skip_if_window_inactive)
 
 
 def mouse_left_check(event: Event):

--- a/Script/UI/Moudle/draw.py
+++ b/Script/UI/Moudle/draw.py
@@ -95,11 +95,11 @@ class WaitDraw(NormalDraw):
         if self.width <= 0 or not self.text:
             io_init.era_print(self.text, self.style, tooltip=self.tooltip)
             if int(len(self.text)):
-                # 右键激活跳过标志时忽略等待，否则正常停顿等待玩家操作
-                if not cache.wframe_mouse.w_frame_skip_wait_mouse:
+                # 右键、系统跳过或Ctrl长按生效时忽略被动等待。
+                if not flow_handle.is_wait_skip_active():
                     flow_handle.askfor_wait()
                 else:
-                    time.sleep(0.001)
+                    time.sleep(flow_handle.get_wait_skip_delay())
             return
         text = self.text
         # 当前剩余待输出的文本
@@ -120,11 +120,11 @@ class WaitDraw(NormalDraw):
             text = text[len(now_text):]
         # 输出后等待玩家操作
         if int(len(self.text)):
-            # 右键激活跳过标志时忽略等待，否则正常停顿等待玩家操作
-            if not cache.wframe_mouse.w_frame_skip_wait_mouse:
+            # 右键、系统跳过或Ctrl长按生效时忽略被动等待。
+            if not flow_handle.is_wait_skip_active():
                 flow_handle.askfor_wait()
             else:
-                time.sleep(0.001)
+                time.sleep(flow_handle.get_wait_skip_delay())
 
 class LineFeedWaitDraw(NormalDraw):
     """
@@ -177,10 +177,10 @@ class LineFeedWaitDraw(NormalDraw):
                 if remain:
                     io_init.era_print("\n")
                 # 等待玩家操作
-                if not cache.wframe_mouse.w_frame_skip_wait_mouse:
+                if not flow_handle.is_wait_skip_active():
                     flow_handle.askfor_wait()
                 else:
-                    time.sleep(0.001)
+                    time.sleep(flow_handle.get_wait_skip_delay())
             io_init.era_print("\n")
 
 class ImageDraw:

--- a/Script/UI/Moudle/panel.py
+++ b/Script/UI/Moudle/panel.py
@@ -308,10 +308,10 @@ class LeftDrawTextListWaitPanel(LeftDrawTextListPanel):
             for value in now_list:
                 value.draw()
             io_init.era_print("\n")
-        if not cache.wframe_mouse.w_frame_skip_wait_mouse:
+        if not flow_handle.is_wait_skip_active():
             flow_handle.askfor_wait()
         else:
-            time.sleep(0.001)
+            time.sleep(flow_handle.get_wait_skip_delay())
 
     def __len__(self):
         """获取面板的内容宽度"""


### PR DESCRIPTION
## 功能说明

新增桌面端按住 `Ctrl` 快速推进对话的功能，减少阅读大量文本时反复点击鼠标或按键的操作。

## 主要改动

- 支持左侧和右侧 `Ctrl` 键。
- 按下 `Ctrl` 时立即结束当前文本的逐字显示与等待。
- 持续按住 `Ctrl` 时自动推进后续对话。
- 松开 `Ctrl` 后恢复正常等待。
- 切换到其他窗口时自动清除快进状态，避免出现持续快进。
- 不向输入队列写入指令，不会自动选择事件选项、菜单或 Debug 功能。
- 保留原有右键跳过和系统自动跳过行为。
- 跳过间隔设置为了0.1秒

## 本地测试
- 经过本地测试，能够正常完成编译，模块功能运行正常
- 暂未发现冲突。甜品功能，对其他模块影响不大

以上，烦请作者抽出时间审阅并提出意见
Appreciate your time and have a nice day : )